### PR TITLE
Changed .vmi timestamp format

### DIFF
--- a/lib/api/evmu/fs/evmu_vmi.h
+++ b/lib/api/evmu/fs/evmu_vmi.h
@@ -70,6 +70,17 @@ GBL_DECLS_BEGIN
 
 GBL_FORWARD_DECLARE_STRUCT(EvmuVms);
 
+//! .VMI timestamp. Unlike EvmuTimestamp it is not stored in BCD format
+typedef struct EvmuVmiTimestamp {
+    uint16_t year;      //!< Date year
+    uint8_t month;      //!< Date month (1-12)
+    uint8_t day;        //!< Date day (1-31)
+    uint8_t hour;       //!< Time hour (0-23)
+    uint8_t minute;     //!< Time minute (0-59)
+    uint8_t second;     //!< Time second (0-59)
+    uint8_t weekDay;    //!< Day of the week (0-6)
+} EvmuTimestamp;
+
 /*! Structure of the .VMI file format
  *  \ingroup file_formats
  *
@@ -84,17 +95,17 @@ GBL_FORWARD_DECLARE_STRUCT(EvmuVms);
  *  \sa EvmuVms
  */
 typedef struct EvmuVmi {
-    uint32_t      checksum;                                     //!< Checksum value for entire structure
-    char          description[EVMU_VMI_DESCRIPTION_SIZE];       //!< Description of VMI file string
-    char          copyright[EVMU_VMI_COPYRIGHT_SIZE];           //!< Copyright information string
-    EvmuTimestamp creationTimestamp;                            //!< File creation date
-    uint16_t      vmiVersion;                                   //!< VMI version of the file, see \ref EVMU_VMI_VERSION
-    uint16_t      fileNumber;                                   //!< File number in a series
-    char          vmsResourceName[EVMU_VMI_VMS_RESOURCE_SIZE];  //!< File name of the corresponding VMS file, expected within the same directory
-    char          fileNameOnVms[EVMU_VMI_VMS_NAME_SIZE];        //!< File name field within the .VMS file
-    uint16_t      fileMode;                                     //!< File mode bitfield (GAME bit + PROTECTED bit)
-    uint16_t      unknown;                                      //!< Unknown and undocumented (assumed to be 0)
-    uint32_t      fileSize;                                     //!< File size of VMS (in bytes?)
+    uint32_t            checksum;                                     //!< Checksum value for entire structure
+    char                description[EVMU_VMI_DESCRIPTION_SIZE];       //!< Description of VMI file string
+    char                copyright[EVMU_VMI_COPYRIGHT_SIZE];           //!< Copyright information string
+    EvmuVmiTimestamp    creationTimestamp;                            //!< File creation date
+    uint16_t            vmiVersion;                                   //!< VMI version of the file, see \ref EVMU_VMI_VERSION
+    uint16_t            fileNumber;                                   //!< File number in a series
+    char                vmsResourceName[EVMU_VMI_VMS_RESOURCE_SIZE];  //!< File name of the corresponding VMS file, expected within the same directory
+    char                fileNameOnVms[EVMU_VMI_VMS_NAME_SIZE];        //!< File name field within the .VMS file
+    uint16_t            fileMode;                                     //!< File mode bitfield (GAME bit + PROTECTED bit)
+    uint16_t            unknown;                                      //!< Unknown and undocumented (assumed to be 0)
+    uint32_t            fileSize;                                     //!< File size of VMS (in bytes?)
 } EvmuVmi;
 
 GBL_STATIC_ASSERT(sizeof(EvmuVmi) == EVMU_VMI_FILE_SIZE)

--- a/lib/source/fs/evmu_vmi.c
+++ b/lib/source/fs/evmu_vmi.c
@@ -28,7 +28,7 @@ EVMU_EXPORT GblBool EvmuVmi_isValid(const EvmuVmi* pSelf) {
 }
 
 EVMU_EXPORT GblDateTime* EvmuVmi_creation(const EvmuVmi* pSelf, GblDateTime* pDateTime) {
-    return EvmuTimestamp_dateTime(&pSelf->creationTimestamp, pDateTime);
+    return EvmuVmiTimestamp_dateTime(&pSelf->creationTimestamp, pDateTime);
 }
 
 EVMU_EXPORT GblBool EvmuVmi_isGame(const EvmuVmi* pSelf) {
@@ -65,7 +65,7 @@ EVMU_VMI_STRING_SET_(VmsResource, vmsResourceName, EVMU_VMI_VMS_RESOURCE_SIZE)
 EVMU_VMI_STRING_SET_(FileName,    fileNameOnVms,   EVMU_VMI_VMS_NAME_SIZE)
 
 EVMU_EXPORT void EvmuVmi_setCreation(EvmuVmi* pSelf, const GblDateTime* pDateTime) {
-    EvmuTimestamp_setDateTime(&pSelf->creationTimestamp, pDateTime);
+    EvmuVmiTimestamp_setDateTime(&pSelf->creationTimestamp, pDateTime);
 }
 
 EVMU_EXPORT void EvmuVmi_setGame(EvmuVmi* pSelf, GblBool value) {
@@ -112,6 +112,28 @@ void EvmuVmi_log(const EvmuVmi* pSelf) {
     EVMU_LOG_POP(1);
 
     GblStringBuffer_destruct(&str.buff);
+}
+
+EVMU_EXPORT void EvmuVmiTimestamp_setDateTime(EvmuVmiTimestamp* pSelf, const GblDateTime* pDateTime) {
+    pSelf->year    = DateTime->date.year;
+    pSelf->month   = pDateTime->date.month;
+    pSelf->day     = pDateTime->date.day;
+    pSelf->hour    = pDateTime->time.hours;
+    pSelf->minute  = pDateTime->time.minutes;
+    pSelf->second  = pDateTime->time.seconds;
+    pSelf->weekDay = GblDate_weekDay(&pDateTime->date);
+}
+
+EVMU_EXPORT GblDateTime* EvmuVmiTimestamp_dateTime(const EvmuVmiTimestamp* pSelf, GblDateTime* pDateTime) {
+    pDateTime->date.year     = pSelf->year;
+    pDateTime->date.month    = pSelf->month;
+    pDateTime->date.day      = pSelf->day;
+    pDateTime->time.hours    = pSelf->hour;
+    pDateTime->time.minutes  = pSelf->minute;
+    pDateTime->time.seconds  = pSelf->second;
+    pDateTime->time.nSeconds = 0;
+
+    return pDateTime;
 }
 
 EVMU_EXPORT EVMU_RESULT EvmuVmi_load(EvmuVmi* pSelf, const char* pPath) {
@@ -195,8 +217,8 @@ EVMU_EXPORT EVMU_RESULT EvmuVmi_fromVmsFile(EvmuVmi*    pSelf,
     memcpy(pSelf->fileNameOnVms,   pVms->dcDesc,  EVMU_VMI_VMS_NAME_SIZE);
 
     GblDateTime dt;
-    EvmuTimestamp_setDateTime(&pSelf->creationTimestamp,
-                              GblDateTime_nowLocal(&dt));
+    EvmuVmiTimestamp_setDateTime(&pSelf->creationTimestamp,
+                                 GblDateTime_nowLocal(&dt));
 
     pSelf->fileNumber = 1;
     pSelf->vmiVersion = EVMU_VMI_VERSION;
@@ -239,8 +261,8 @@ EVMU_EXPORT EVMU_RESULT EvmuVmi_fromDirEntry(EvmuVmi*           pSelf,
                    EVMU_VMI_COPYRIGHT_SIZE));
 
     // Set creation timestamp
-    EvmuTimestamp_setDateTime(&pSelf->creationTimestamp,
-                              GblDateTime_nowLocal(&dt));
+    EvmuVmiTimestamp_setDateTime(&pSelf->creationTimestamp,
+                                 GblDateTime_nowLocal(&dt));
     // Set VMI version
     pSelf->vmiVersion = EVMU_VMI_VERSION;
 


### PR DESCRIPTION
This is an early PR for code review to see if I'm on the right track or not. I don't really know where things should go, nor if there's tests I should be running, etc etc etc. I tried to guess at naming and formatting conventions. I haven't tried building it.

The background here is that I believe that `.vmi` files have a different timestamp format than the native VMU files. The native VMU files are encoded with BCD but I believe that `.vmi` files are not. At least based on the small sample that I've observed.

I think that the date fields in `.vmi` files should be treated just as straight uint8s rather than BCD-encoded uint8s, and that the year is a little-endian uint16.

I got all the examples below from the same site, so there's a possibility that something specific to this site is the root cause. But I also don't know where else to find `.vmi` files.

Some examples:

https://bucanero.github.io/dreamcast-saves/ikaruga/
<img width="718" height="102" alt="Screenshot 2025-10-08 at 4 39 55 PM" src="https://github.com/user-attachments/assets/8ebad45f-0669-45a0-8648-a7f3411f0615" />
I believe this date is `2002-09-07 20:22:06`. At the very least, the year does not look like BCD to me.

https://bucanero.github.io/dreamcast-saves/kisspsycho/
<img width="723" height="101" alt="Screenshot 2025-10-10 at 4 01 42 PM" src="https://github.com/user-attachments/assets/62b1b2a5-aacc-44f0-b194-5f5375a6278c" />
I believe this date is `2004-09-16 08:55:18`. Ditto for the year here

https://bucanero.github.io/dreamcast-saves/gauntletlegends/
<img width="722" height="90" alt="Screenshot 2025-10-10 at 4 04 36 PM" src="https://github.com/user-attachments/assets/52871599-ef2a-4ae0-ac6e-ff2b3725d710" />
I believe this date is `1998-12-25 12:00:00`. Here in addition to the year, the month and hour also don't look like BCD

https://bucanero.github.io/dreamcast-saves/jetgrindradio/
<img width="718" height="97" alt="Screenshot 2025-10-10 at 4 11 34 PM" src="https://github.com/user-attachments/assets/88cd2228-49cb-48b9-9f34-9f964a5c295d" />
Same date of `1998-12-25 12:00:00` on this file as well for whatever reason

