### PR TITLE
Fix VMS file loading, type detection, and doc corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ CMakeLists.txt.user.*
 build/
 build_*
 build-*
+.cache/
+doc/html/
+doc/latex/
+doc/xml/

--- a/doc/pages/mem_map.dox
+++ b/doc/pages/mem_map.dox
@@ -111,8 +111,8 @@ memory resides.
 |0B0-0BF|^                                              |^                               |^           |
 |0A0-0AF|^                                              |^                               |^           |
 |090-09F|^                                              |^                               |^           |
-|080-08F|\link system_variables System/BIOS RAM \endlink|^                               |^           |
-|070-07F|^                                              |^                               |^           | 
+|080-08F|^                                              |^                               |^           |
+|070-07F|\link system_variables System/BIOS RAM \endlink|^                               |^           | 
 |060-06F|^                                              |^                               |^           |
 |050-05F|^                                              |^                               |^           |
 |040-04F|^                                              |^                               |^           |

--- a/legacy/source/gyro_vmu_flash.c
+++ b/legacy/source/gyro_vmu_flash.c
@@ -376,8 +376,8 @@ EvmuDirEntry* gyVmuFlashLoadImageVmiVms(EvmuDevice* dev, const char* vmipath, co
     }
 
     EvmuVmi vmi;
-    if(!EvmuVmi_load(&vmi, vmipath)) {
-        if(!EvmuVmi_fromVmsFile(&vmi, vms, vmsSize)) {
+    if(!GBL_RESULT_SUCCESS(EvmuVmi_load(&vmi, vmipath))) {
+        if(!GBL_RESULT_SUCCESS(EvmuVmi_fromVmsFile(&vmi, vms, vmsSize))) {
             *status = VMU_LOAD_IMAGE_OPEN_FAILED;
             goto end;
         }

--- a/lib/source/fs/evmu_vms.c
+++ b/lib/source/fs/evmu_vms.c
@@ -34,7 +34,8 @@ EVMU_EXPORT GblBool EvmuVms_isValid(const EvmuVms* pSelf) {
                 return GBL_FALSE;
         }
 
-        if(pSelf->iconCount && !pSelf->animSpeed)
+        // Only require animSpeed when multiple icons need animating
+        if(pSelf->iconCount > 1 && !pSelf->animSpeed)
             return GBL_FALSE;
 
         return GBL_TRUE;
@@ -125,7 +126,9 @@ EVMU_EXPORT EVMU_FILE_TYPE EvmuVms_guessFileType(const EvmuVms* pSelf) {
        pSelf->dataBytes == EvmuVms_totalBytes(pSelf) - EvmuVms_headerBytes(pSelf)
       )
         return EVMU_FILE_TYPE_DATA;
-    else if(EvmuVms_isValid(pSelf) && !pSelf->crc && !pSelf->dataBytes)
+    // Relaxed: ignore dataBytes for GAME detection, since production games
+    // like Shenmue and NanwakaDensetsu set dataBytes in their GAME headers.
+    else if(EvmuVms_isValid(pSelf) && !pSelf->crc)
         return EVMU_FILE_TYPE_GAME;
     else
         return EVMU_FILE_TYPE_NONE;


### PR DESCRIPTION
- Fix boolean check on EVMU_RESULT in gyVmuFlashLoadImageVmiVms: use GBL_RESULT_SUCCESS() macro instead of bare `!` operator, since GBL_RESULT_SUCCESS is 0x1 not 0. Without this, EvmuVmi_fromVmsFile() was never called for standalone .vms files without a companion .vmi.
- Relax EvmuVms_isValid() to allow single-icon VMS files with animSpeed=0. Many real-world GAME files have one static icon that doesn't need an animation speed.
- Fix memory map documentation: stack area starts at 0x80, not 0x90.
- Add doxygen output directories and .cache to .gitignore.