### PR TITLE
Bugs found by Claude Pt3

### DIFF
--- a/lib/api/evmu/fs/evmu_file_manager.h
+++ b/lib/api/evmu/fs/evmu_file_manager.h
@@ -25,6 +25,7 @@
 //! @}
 
 #define EVMU_FILE_MANAGER_NAME              "filemanager"   //!< EvmuFileManager GblObject name
+#define EVMU_FILE_INDEX_INVALID             ((size_t)-1)    //!< Sentinel returned when a file index lookup fails
 
 #define GBL_SELF_TYPE EvmuFileManager
 
@@ -150,7 +151,7 @@ EVMU_EXPORT EVMU_RESULT   EvmuFileManager_export (GBL_CSELF,
 //! Returns the total byte size of the file on the filesystem, including the VMS header, icons, eyecatc, etc.
 EVMU_EXPORT size_t   EvmuFileManager_bytes (GBL_CSELF,
                                             const EvmuDirEntry* pEntry) GBL_NOEXCEPT;
-//! Returns the file index corresponding to a given directory entry for a file
+//! Returns the file index corresponding to a given directory entry for a file, or EVMU_FILE_INDEX_INVALID if not found
 EVMU_EXPORT size_t   EvmuFileManager_index (GBL_CSELF,
                                             const EvmuDirEntry* pEntry) GBL_NOEXCEPT;
 //! Returns the VMS header segment (ONLY) for an existing file (not the entire VMS data with icons, eyecatch, etc)

--- a/lib/api/evmu/hw/evmu_sfr.h
+++ b/lib/api/evmu/hw/evmu_sfr.h
@@ -22,7 +22,7 @@ extern "C" {
 #define EVMU_SFR_PSW_IRBK0_POS       3
 #define EVMU_SFR_PSW_IRBK0_MASK      0x8
 #define EVMU_SFR_PSW_OV_POS          2       //Overflow Flag - set when overflow occurs in signed addition or subtraction or
-#define EVMU_SFR_PSW_OV_MASK         0x4     //  result of a multiplication exceeds 256. Set to 0 when divide by 0 is performed
+#define EVMU_SFR_PSW_OV_MASK         0x4     //  result of a multiplication exceeds 256. For DIV, set to 1 when the divisor is zero
 #define EVMU_SFR_PSW_RAMBK0_POS      1       //RAM Bank - Selects 1 of two banks for 256 general-purpose RAM bytes at (0x0-0xff)
 #define EVMU_SFR_PSW_RAMBK0_MASK     0x2     //  Bank 0 for system and CPU stack. Bank 1 for game software (firmware automatically changes before entering game mode)
 #define EVMU_SFR_PSW_P_POS           0       //ACC Parity - set when number of bits in accumulator is odd

--- a/lib/source/fs/evmu_file_manager.c
+++ b/lib/source/fs/evmu_file_manager.c
@@ -782,9 +782,10 @@ static EVMU_RESULT EvmuFileManager_loadFlash_(EvmuFileManager* pSelf, const char
 
     size_t read = 0;
     while(read < toRead) {
+        const size_t remaining = toRead - read;
         const size_t chunkSize =
-            toRead > EVMU_FAT_BLOCK_SIZE?
-            EVMU_FAT_BLOCK_SIZE : toRead;
+            remaining > EVMU_FAT_BLOCK_SIZE?
+            EVMU_FAT_BLOCK_SIZE : remaining;
 
         size_t retVal =
             fread(fillBuffer, 1, chunkSize, pFile);

--- a/lib/source/fs/evmu_file_manager.c
+++ b/lib/source/fs/evmu_file_manager.c
@@ -31,23 +31,21 @@ EVMU_EXPORT size_t EvmuFileManager_count(const EvmuFileManager* pSelf) {
 }
 
 EVMU_EXPORT EvmuDirEntry* EvmuFileManager_file(const EvmuFileManager* pSelf, size_t index) {
-    EvmuDirEntry* pEntry = NULL;
     size_t        count  = 0;
     EvmuFat*      pFat   = EVMU_FAT(pSelf);
 
     const size_t dirEntryCount = EvmuFat_dirEntryCount(pFat);
     for(size_t d = 0; d < dirEntryCount; ++d) {
-        pEntry = EvmuFat_dirEntry(pFat, d);
+        EvmuDirEntry* pEntry = EvmuFat_dirEntry(pFat, d);
         GBL_ASSERT(pEntry);
 
         if(pEntry->fileType != EVMU_FILE_TYPE_NONE) {
-            if(count++ == index) {
-                break;
-            }
+            if(count++ == index)
+                return pEntry;
         }
     }
 
-    return pEntry;
+    return NULL;
 }
 
 EVMU_EXPORT size_t EvmuFileManager_index(const EvmuFileManager* pSelf, const EvmuDirEntry* pEntry) {

--- a/lib/source/fs/evmu_file_manager.c
+++ b/lib/source/fs/evmu_file_manager.c
@@ -50,6 +50,30 @@ EVMU_EXPORT EvmuDirEntry* EvmuFileManager_file(const EvmuFileManager* pSelf, siz
     return pEntry;
 }
 
+EVMU_EXPORT size_t EvmuFileManager_index(const EvmuFileManager* pSelf, const EvmuDirEntry* pEntry) {
+    size_t   index = 0;
+    EvmuFat* pFat  = EVMU_FAT(pSelf);
+
+    if(!pEntry || pEntry->fileType == EVMU_FILE_TYPE_NONE)
+        return EVMU_FILE_INDEX_INVALID;
+
+    const size_t dirEntryCount = EvmuFat_dirEntryCount(pFat);
+    for(size_t d = 0; d < dirEntryCount; ++d) {
+        EvmuDirEntry* pCur = EvmuFat_dirEntry(pFat, d);
+        GBL_ASSERT(pCur);
+
+        if(pCur->fileType == EVMU_FILE_TYPE_NONE)
+            continue;
+
+        if(pCur == pEntry)
+            return index;
+
+        ++index;
+    }
+
+    return EVMU_FILE_INDEX_INVALID;
+}
+
 EVMU_EXPORT size_t EvmuFileManager_free(EvmuFileManager* pSelf, EvmuDirEntry* pEntry) {
     size_t blocksFreed = 0;
     struct {

--- a/lib/source/fs/evmu_file_manager.c
+++ b/lib/source/fs/evmu_file_manager.c
@@ -603,22 +603,17 @@ EVMU_EXPORT size_t EvmuFileManager_write(const EvmuFileManager* pSelf,
 
     // Iterate over blocks to find the starting block
     EvmuBlock startBlock = pEntry->firstBlock;
-    for(size_t b = 1; b < startBlockIdx; ++b)
+    for(size_t b = 0; b < startBlockIdx; ++b)
         startBlock = EvmuFat_blockNext(pFat, startBlock);
-
-    // Iterate over blocks to find the ending block
-    EvmuBlock endBlock = startBlock;
-    for(size_t b = 1; b < blockCount; ++b)
-        endBlock = EvmuFat_blockNext(pFat, endBlock);
 
     // Iterate from start to end block, writing block-sized chunks
     EvmuBlock curBlock     = startBlock;
     size_t    remaining    = size;
-    for(size_t b = 0; b < blockCount; ++b) {
+    for(size_t b = 0; remaining > 0; ++b) {
         size_t writeBytes = (remaining < blockSize)?
                              remaining : blockSize;
 
-        const size_t blockOffset = b * blockSize + (b? 0 : offset);
+        const size_t blockOffset = curBlock * blockSize + (b == 0 ? offset % blockSize : 0);
 
         GBL_CTX_CALL(EvmuFlash_writeBytes(pFlash,
                                           blockOffset,

--- a/lib/source/fs/evmu_vmi.c
+++ b/lib/source/fs/evmu_vmi.c
@@ -224,7 +224,7 @@ EVMU_EXPORT EVMU_RESULT EvmuVmi_fromVmsFile(EvmuVmi*    pSelf,
     pSelf->vmiVersion = EVMU_VMI_VERSION;
     pSelf->fileSize   = bytes;
     pSelf->fileMode   = fileType == EVMU_FILE_TYPE_GAME? EVMU_VMI_GAME_MASK : 0;
-    pSelf->checksum   = gblHashCrc16BitPartial(pVms, pSelf->fileSize, NULL);
+    pSelf->checksum   = EvmuVmi_computeChecksum(pSelf);
 
     EvmuVmi_log(pSelf);
 

--- a/lib/source/hw/evmu_cpu.c
+++ b/lib/source/hw/evmu_cpu.c
@@ -304,20 +304,22 @@ static  EVMU_RESULT EvmuCpu_execute_(EvmuCpu* pSelf, const EvmuDecodedInstructio
         BR_CMP(READ(INDIRECT()), ==, OP(immediate), OP(relative8));
         break;
     case EVMU_OPCODE_DIV: {
-        int r  =  READ(SFR(B)), s;
-        if(r) {
+        const int divisor = READ(SFR(B));
+        int quotient, remainder;
+
+        if(divisor) {
             const int v = READ(SFR(C)) | (READ(SFR(ACC)) << 8);
-            s = v % r;
-            r = v / r;
+            remainder = v % divisor;
+            quotient = v / divisor;
+            WRITE(SFR(B), remainder);
+            WRITE(SFR(C), quotient & 0xff);
+            WRITE(SFR(ACC), (quotient & 0xff00) >> 8);
         } else {
-            r = 0xff00 | READ(SFR(C));
-            s = 0;
+            WRITE(SFR(ACC), 0xff);
         }
-        WRITE(SFR(B),    s);
-        WRITE(SFR(C),    r & 0xff);
-        WRITE(SFR(ACC), (r & 0xff00) >> 8);
+
         PSW(CY, 0);
-        PSW(OV, !s);
+        PSW(OV, !divisor);
         break;
     }
     case EVMU_OPCODE_BNEI:
@@ -709,4 +711,3 @@ GBL_EXPORT GblType EvmuCpu_type(void) {
     }
     return type;
 }
-

--- a/lib/source/hw/evmu_isa.c
+++ b/lib/source/hw/evmu_isa.c
@@ -251,7 +251,7 @@ static const EvmuInstructionFormat opcodeMap_[EVMU_OPCODE_MAP_SIZE] = {
     },
     [EVMU_OPCODE_DIV] = {
         "DIV",
-        "Perform a division. The ACC and C registers together form a 16-bit operand (ACC being the high 8 bits, and C being the low 8 bits) which is divided by the contents of the B register. The result is a 16-bit quotient that is stored in ACC and C (the high 8 bits in ACC, and the low 8 bits in C), and an 8-bit remainder that is stored in B. CY is cleared, and OV is set if the remainder is zero, otherwise cleared. AC is not affected.",
+        "Perform a division. The ACC and C registers together form a 16-bit operand (ACC being the high 8 bits, and C being the low 8 bits) which is divided by the contents of the B register. The result is a 16-bit quotient that is stored in ACC and C (the high 8 bits in ACC, and the low 8 bits in C), and an 8-bit remainder that is stored in B. CY is cleared, and OV is set if the divisor is zero, otherwise cleared. AC is not affected.",
         EVMU_OPCODE_DIV,
         8,
         EVMU_ISA_ARG_FORMAT_PACK(EVMU_ISA_ARG_TYPE_NONE),

--- a/lib/source/hw/evmu_rom.c
+++ b/lib/source/hw/evmu_rom.c
@@ -138,13 +138,15 @@ static void biosWriteFlashRom_(EvmuRom_* pSelf_) {
 
     int i, a = ((pDevice_->pRam->ram[1][0x7d]<<16)|(pDevice_->pRam->ram[1][0x7e]<<8)|pDevice_->pRam->ram[1][0x7f])&0x1ffff;
     EvmuDirEntry* pEntry = EvmuFileManager_game(pDevice->pFileMgr);
+    const int gameBase = pEntry? pEntry->firstBlock * EVMU_FAT_BLOCK_SIZE : 0;
+    const int gameEnd  = pEntry? gameBase + pEntry->fileSize * EVMU_FAT_BLOCK_SIZE : 0;
 
-    if(!pEntry ||  a >= pEntry->fileSize * EVMU_FAT_BLOCK_SIZE)
+    if(!pEntry || a < gameBase || a + EVMU_FLASH_PROGRAM_BYTE_COUNT > gameEnd)
         EvmuRam_writeData(pDevice->pRam, 0x100, 0xff);
     else {
         EvmuRam_writeData(pDevice->pRam, 0x100, 0x00);
         for(i=0; i<0x80; i++) {
-            const uint16_t flashAddr = (a&~0xff)|((a+i)&0xff);
+            const EvmuAddress flashAddr = (a&~0xff)|((a+i)&0xff);
             pDevice_->pFlash->pStorage->pData[flashAddr] = pDevice_->pRam->ram[1][i+0x80];
         }
     }


### PR DESCRIPTION
This PR fixes a group of correctness issues across the filesystem, raw flash loading, BIOS flash writes, VMI generation, and CPU `DIV` emulation.

## What changed

- Fix `EvmuVmi_fromVmsFile()` to use the SEGA VMI checksum routine instead of CRC16, so synthesized VMI files validate correctly.
- Fix `EvmuFileManager_write()` so it walks the FAT chain from the correct starting block and writes to the actual physical flash block address instead of a linear offset.
- Implement the missing public `EvmuFileManager_index()` API and document `EVMU_FILE_INDEX_INVALID` as its failure sentinel.
- Fix `EvmuFileManager_file()` so out-of-range lookups return `NULL` instead of the last iterated directory entry.
- Fix `EvmuFileManager_loadFlash_()` so the final chunk size is computed from the remaining byte count, which makes short raw flash image handling consistent with the function’s existing warning/clamp behavior.
- Fix the BIOS flash writer bounds check so it validates against the active game’s physical flash window instead of comparing an absolute flash address against a relative file size.
- Update `DIV` so `OV` is set only when the divisor is zero, and align the ISA / PSW documentation with that behavior.
