### PR TITLE
Mode-1 ELDT1C fixes

### DIFF
--- a/lib/api/evmu/hw/evmu_sfr.h
+++ b/lib/api/evmu/hw/evmu_sfr.h
@@ -111,8 +111,8 @@ Bios initializes bit 3 to 1 and never EVER changes it.
 #define EVMU_SFR_T1CNT_T1LRUN_MASK   0x40
 #define EVMU_SFR_T1CNT_T1LONG_POS    5       //16-bit Timer Enable - 1 combines T1H and T1L into one 16-bit timer
 #define EVMU_SFR_T1CNT_T1LONG_MASK   0x20    //  0 keeps them two separate 8-bit timers
-#define EVMU_SFR_T1CNT_ELDT1C_POS    4       //Timer 1 Compare Data Load Enable - When 0, writes to T1LC and T1HC will not take effect until set to 1 again.
-#define EVMU_SFR_T1CNT_ELDT1C_MASK   0x10    //  Can be used to set 16-bit compare value automatically (ignored when no timers are running)
+#define EVMU_SFR_T1CNT_ELDT1C_POS    4       //Timer 1 Compare Data Load Enable - While Timer 1 is running, 0 holds the active compare data and 1 allows a later reload point to latch new T1LC/T1HC values.
+#define EVMU_SFR_T1CNT_ELDT1C_MASK   0x10    //  When Timer 1 is stopped, compare writes take effect immediately.
 #define EVMU_SFR_T1CNT_T1HOVF_POS    3       //Timer 1 High Overflow - set to 1 when T1H overflows
 #define EVMU_SFR_T1CNT_T1HOVF_MASK   0x8
 #define EVMU_SFR_T1CNT_T1HIE_POS     2       //Timer 1 High Interrupt Enable
@@ -299,4 +299,3 @@ Bios initializes bit 3 to 1 and never EVER changes it.
 #endif
 
 #endif // EVMU_SFR_H
-

--- a/lib/source/hw/evmu_buzzer.c
+++ b/lib/source/hw/evmu_buzzer.c
@@ -113,9 +113,6 @@ void EvmuBuzzer__memorySink_(EvmuBuzzer_* pSelf_, EvmuAddress address, EvmuWord 
                    address != EVMU_ADDRESS_SFR_T1LC)
                 {
                     EvmuBuzzer_updateTone_(pSelf);
-                } else if(!pSelf_->active) {
-                    EvmuBuzzer_latchMode1Registers_(pSelf_, GBL_TRUE);
-                    EvmuBuzzer_updateTone_(pSelf);
                 }
 
                 if(!pSelf_->active)


### PR DESCRIPTION
- ELDT1C=0 no longer lets live T1LC writes leak through while Timer1 is running in mode 1
- ELDT1C=1 now defers comparator updates to the proper reload point instead of updating continuously mid-cycle

Partial fix to #8. Mode 3 not implemented yet.