### PR TITLE
Refactor(clock): decode OCR selector explicitly

### DIFF
--- a/lib/api/evmu/hw/evmu_sfr.h
+++ b/lib/api/evmu/hw/evmu_sfr.h
@@ -95,14 +95,14 @@ Bios initializes bit 3 to 1 and never EVER changes it.
 //OCR - Oscillation Control Register (0x10e)
 #define EVMU_SFR_OCR_OCR7_POS        7       //Clock Divisor - when 0, divides clock frequency by 12
 #define EVMU_SFR_OCR_OCR7_MASK       0x80    //  when 1, divides clock frequency by 6
-#define EVMU_SFR_OCR_OCR5_POS        5       //Subclock Mode Enabled - when 1, enables sublock mode (32kHz) (slow and power conserving)
-#define EVMU_SFR_OCR_OCR5_MASK       0x20    //  when 0, enables RC clock mode (600kHz), uses more power
-#define EVMU_SFR_OCR_OCR4_POS        4       //Main Clock Mode Enable - when 1, enables main clock (6Mhz)
-#define EVMU_SFR_OCR_OCR4_MASK       0x10    //  should only be set when subclock mode is disabled and plugged into controller
+#define EVMU_SFR_OCR_OCR5_POS        5       //System Clock Selector bit 1
+#define EVMU_SFR_OCR_OCR5_MASK       0x20    //  OCR5:OCR4 = 00 RC, 01 CF, 10 Quartz, 11 CF
+#define EVMU_SFR_OCR_OCR4_POS        4       //System Clock Selector bit 0
+#define EVMU_SFR_OCR_OCR4_MASK       0x10    //  OCR5:OCR4 = 00 RC, 01 CF, 10 Quartz, 11 CF
 #define EVMU_SFR_OCR_OCR1_POS        1       //RC Clock Control - when 1, stops RC oscillator
 #define EVMU_SFR_OCR_OCR1_MASK       0x2     //  preserves power, can only be done in subclock mode
-#define EVMU_SFR_OCR_OCR0_POS        0       //Main Clock Control - when 1, stops main clock
-#define EVMU_SFR_OCR_OCR0_MASK       0x1     //  should always be set when VMS isn't docked
+#define EVMU_SFR_OCR_OCR0_POS        0       //CF Clock Control - when 1, stops CF oscillator
+#define EVMU_SFR_OCR_OCR0_MASK       0x1     //  should usually be set when the VMU isn't docked
 
 //T1CNT - Timer 1 Control (0x118)
 #define EVMU_SFR_T1CNT_T1HRUN_POS    7       //Timer 1 High Running - 1 starts T1H timer, 0 stops it

--- a/lib/source/hw/evmu_clock.c
+++ b/lib/source/hw/evmu_clock.c
@@ -69,6 +69,32 @@ static EvmuCycles EvmuClockSignal_update_(EvmuClockSignal_* pSelf, EvmuTicks del
     return pSelf->halfCyclesTotal - prevHalfCycles;
 }
 
+static EVMU_OSCILLATOR EvmuClock_oscillatorFromOcr_(EvmuWord ocr) {
+    switch((ocr >> EVMU_SFR_OCR_OCR4_POS) & 0x3u) {
+    case 0x1u:
+    case 0x3u:
+        return EVMU_OSCILLATOR_CF;
+    case 0x2u:
+        return EVMU_OSCILLATOR_QUARTZ;
+    default:
+        return EVMU_OSCILLATOR_RC;
+    }
+}
+
+static EvmuTicks EvmuClock_ticksPerCycle_(EVMU_OSCILLATOR oscillator, GblBool div6) {
+    switch(oscillator) {
+    case EVMU_OSCILLATOR_CF:
+        return div6? EVMU_CLOCK_OSC_CF_TCYC_1_6 :
+                     EVMU_CLOCK_OSC_CF_TCYC_1_12;
+    case EVMU_OSCILLATOR_QUARTZ:
+        return div6? EVMU_CLOCK_OSC_QUARTZ_TCYC_1_6 :
+                     EVMU_CLOCK_OSC_QUARTZ_TCYC_1_12;
+    default:
+        return div6? EVMU_CLOCK_OSC_RC_TCYC_1_6 :
+                     EVMU_CLOCK_OSC_RC_TCYC_1_12;
+    }
+}
+
 
 static GBL_RESULT EvmuClock_reset_(EvmuIBehavior* pSelf) {
     GBL_CTX_BEGIN(pSelf);
@@ -362,58 +388,35 @@ GBL_EXPORT EVMU_RESULT EvmuClock_setSystemConfig(const EvmuClock* pSelf, EVMU_OS
 
 GBL_EXPORT EvmuTicks EvmuClock_systemTicksPerCycle(const EvmuClock* pSelf) {
     const EvmuWord ocr = EVMU_CLOCK_(pSelf)->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_OCR)];
-    EvmuTicks ticks = 0;
-
-    if(ocr & EVMU_SFR_OCR_OCR4_MASK) {
-        ticks = (ocr & EVMU_SFR_OCR_OCR7_MASK)?
-                    EVMU_CLOCK_OSC_CF_TCYC_1_6 : EVMU_CLOCK_OSC_CF_TCYC_1_12;
-    } else if(ocr & EVMU_SFR_OCR_OCR5_MASK) {
-        ticks = (ocr & EVMU_SFR_OCR_OCR7_MASK)?
-                    EVMU_CLOCK_OSC_QUARTZ_TCYC_1_6: EVMU_CLOCK_OSC_QUARTZ_TCYC_1_12;
-    } else {
-        ticks = (ocr & EVMU_SFR_OCR_OCR7_MASK)?
-                    EVMU_CLOCK_OSC_RC_TCYC_1_6: EVMU_CLOCK_OSC_RC_TCYC_1_12;
-    }
-
-    ticks *= 1000; //msec to nsec
-
-    return ticks;
+    const GblBool div6 = (ocr & EVMU_SFR_OCR_OCR7_MASK) != 0;
+    return EvmuClock_ticksPerCycle_(EvmuClock_oscillatorFromOcr_(ocr),
+                                    div6);
 }
 
 EVMU_EXPORT uint64_t EvmuClock_systemCyclesPerSec(const EvmuClock* pSelf) {
     //unsigned char pcon = dev->sfr[EVMU_SFR_OFFSET(SFR_ADDR_PCON)];
     unsigned char ocr = EVMU_CLOCK_(pSelf)->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_OCR)];
     double val;
+    const GblBool div6 = (ocr & EVMU_SFR_OCR_OCR7_MASK) != 0;
 
     //INACCURATE, THERE IS A REMAINDER FROM THESE DIVISIONS!!!!
-    if(ocr & EVMU_SFR_OCR_OCR4_MASK) {
-        val = ((double)EVMU_CLOCK_OSC_CF_FREQ)/((ocr & EVMU_SFR_OCR_OCR7_MASK)? 6.0 : 12.0);
-    } else if(ocr & EVMU_SFR_OCR_OCR5_MASK) {
-        val = ((double)EVMU_CLOCK_OSC_QUARTZ_FREQ)/((ocr & EVMU_SFR_OCR_OCR7_MASK)? 6.0 : 12.0);
-    } else {
-        val =  ((double)EVMU_CLOCK_OSC_RC_FREQ)/((ocr & EVMU_SFR_OCR_OCR7_MASK)? 6.0 : 12.0);
+    switch(EvmuClock_oscillatorFromOcr_(ocr)) {
+    case EVMU_OSCILLATOR_CF:
+        val = ((double)EVMU_CLOCK_OSC_CF_FREQ)/(div6? 6.0 : 12.0);
+        break;
+    case EVMU_OSCILLATOR_QUARTZ:
+        val = ((double)EVMU_CLOCK_OSC_QUARTZ_FREQ)/(div6? 6.0 : 12.0);
+        break;
+    default:
+        val = ((double)EVMU_CLOCK_OSC_RC_FREQ)/(div6? 6.0 : 12.0);
+        break;
     }
 
     return val;
 }
 
 EVMU_EXPORT double EvmuClock_systemSecsPerCycle(const EvmuClock* pSelf) {
-    const EvmuWord ocr = EVMU_CLOCK_(pSelf)->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_OCR)];
-    const GblBool div6 = !!(ocr & EVMU_SFR_OCR_OCR7_MASK);
-    uint64_t tCyc = 0;
-
-    if(ocr & EVMU_SFR_OCR_OCR4_MASK) {
-        tCyc = div6? EVMU_CLOCK_OSC_CF_TCYC_1_6:
-                   EVMU_CLOCK_OSC_CF_TCYC_1_12;
-    } else if(ocr & EVMU_SFR_OCR_OCR5_MASK) {
-        tCyc = div6? EVMU_CLOCK_OSC_QUARTZ_TCYC_1_6 :
-                   EVMU_CLOCK_OSC_QUARTZ_TCYC_1_12;
-    } else {
-        tCyc = div6? EVMU_CLOCK_OSC_RC_TCYC_1_6 :
-                   EVMU_CLOCK_OSC_RC_TCYC_1_12;
-    }
-
-    return tCyc / 1000000000.0;
+    return EvmuClock_systemTicksPerCycle(pSelf) / 1000000000.0;
 }
 
 
@@ -478,4 +481,3 @@ GBL_EXPORT GblType EvmuClock_type(void) {
 
     return type;
 }
-


### PR DESCRIPTION
Decode OCR5:OCR4 as the documented 2-bit system clock selector instead of relying on implicit priority rules.

Also clean up OCR bit comments and simplify the cycle-time helpers to share a single decode path, including explicit coverage for the 11 -> CF selector case.