### PR TITLE
EvmuWave update/read functions are broken (3 related bugs)

### DIFF
--- a/lib/api/evmu/hw/evmu_wave.h
+++ b/lib/api/evmu/hw/evmu_wave.h
@@ -14,7 +14,7 @@
 
 #define EVMU_WAVE_LOGIC_BITS            2
 #define EVMU_WAVE_LOGIC_CURRENT_MASK    (0x3)
-#define EVMU_WAVE_LOGIC_PREVIOUS_MASK   (0x70)
+#define EVMU_WAVE_LOGIC_PREVIOUS_MASK   (0x3 << EVMU_WAVE_LOGIC_BITS)
 
 #define GBL_SELF_TYPE GblEnum
 
@@ -100,11 +100,11 @@ EVMU_INLINE GblBool     EvmuWave_hasChangedInvalid       (GBL_CSELF)            
 
 EVMU_INLINE void EvmuWave_logicPreviousSet_(GBL_SELF, EVMU_LOGIC value) GBL_NOEXCEPT {
     *pSelf &= ~EVMU_WAVE_LOGIC_PREVIOUS_MASK;
-    *pSelf |= (value << EVMU_WAVE_LOGIC_BITS);
+    *pSelf |= (value << EVMU_WAVE_LOGIC_BITS) & EVMU_WAVE_LOGIC_PREVIOUS_MASK;
 }
 EVMU_INLINE void EvmuWave_logicCurrentSet_(GBL_SELF, EVMU_LOGIC value) GBL_NOEXCEPT {
     *pSelf &= ~EVMU_WAVE_LOGIC_CURRENT_MASK;
-    *pSelf |= (value);
+    *pSelf |= value & EVMU_WAVE_LOGIC_CURRENT_MASK;
 }
 EVMU_INLINE void EvmuWave_reset(GBL_SELF) GBL_NOEXCEPT {
     *pSelf = EVMU_WAVE_X_X;
@@ -120,11 +120,11 @@ EVMU_INLINE EVMU_LOGIC EvmuWave_logicCurrent(GBL_CSELF) GBL_NOEXCEPT {
     return (EVMU_LOGIC)(*pSelf & EVMU_WAVE_LOGIC_CURRENT_MASK);
 }
 EVMU_INLINE EVMU_LOGIC EvmuWave_logicPrevious(GBL_CSELF) GBL_NOEXCEPT {
-    return (EVMU_LOGIC)(*pSelf & EVMU_WAVE_LOGIC_PREVIOUS_MASK);
+    return (EVMU_LOGIC)((*pSelf & EVMU_WAVE_LOGIC_PREVIOUS_MASK) >> EVMU_WAVE_LOGIC_BITS);
 }
 EVMU_INLINE void EvmuWave_update(GBL_SELF, EVMU_LOGIC value) GBL_NOEXCEPT {
-    *pSelf <<= EVMU_WAVE_LOGIC_BITS;
-    *pSelf &= (value & EVMU_WAVE_LOGIC_MASK_);
+    EvmuWave_logicPreviousSet_(pSelf, EvmuWave_logicCurrent(pSelf));
+    EvmuWave_logicCurrentSet_(pSelf, value);
 }
 EVMU_INLINE GblBool EvmuWave_hasStayed(GBL_CSELF) GBL_NOEXCEPT {
     return EvmuWave_logicCurrent(pSelf) == EvmuWave_logicPrevious(pSelf);


### PR DESCRIPTION
- **File:** `lib/api/evmu/hw/evmu_wave.h`
- **Issues:**
  1. Line 17: `EVMU_WAVE_LOGIC_PREVIOUS_MASK` is `0x70` (bits 4-6) but previous logic is stored in bits 2-3. Should be `0xC`.
  2. Line 122-124: `EvmuWave_logicPrevious()` returns raw masked value without right-shifting by `EVMU_WAVE_LOGIC_BITS`.
  3. Line 125-128: `EvmuWave_update()` uses `&=` to set current value — should clear current bits and `|=` the new value.
- **Impact:** Clock signal edge detection is completely broken. `hasStayed()`, `wasLogic()`, `hasChanged()` all return wrong results. Used in `evmu_clock.c` lines 53-95.