### PR TITLE
Claude bugs pt4

### DIFF
--- a/legacy/source/gyro_vmu_flash.c
+++ b/legacy/source/gyro_vmu_flash.c
@@ -885,11 +885,20 @@ int gyVmuFlashExportDci(const EvmuDevice* dev, const EvmuDirEntry* entry, const 
     EVMU_LOG_VERBOSE("Exporting file [%s] to DCI file: [%s]", entryName, path);
     EVMU_LOG_PUSH();
 
-    size_t          dataSize   = sizeof(uint8_t) * paddedFileSize + sizeof(EvmuDirEntry);
-    uint8_t*        data       = malloc(dataSize + dataSize%4? 4-dataSize%4 : 0);
+    size_t          dataSize     = sizeof(uint8_t) * paddedFileSize + sizeof(EvmuDirEntry);
+    size_t          paddingBytes = dataSize % 4? 4 - dataSize % 4 : 0;
+    size_t          bytesToWrite = dataSize + paddingBytes;
+    uint8_t*        data         = malloc(bytesToWrite);
     uint8_t*        vms        = data + sizeof(EvmuDirEntry);
 
-    memset(data, 0, dataSize);
+    if(!data) {
+        strncpy(_lastErrorMsg, "Failed to allocate DCI export buffer!", sizeof(_lastErrorMsg));
+        EVMU_LOG_ERROR("%s", _lastErrorMsg);
+        success = 0;
+        goto free_img;
+    }
+
+    memset(data, 0, bytesToWrite);
     memcpy(data, entry, sizeof(EvmuDirEntry));
 
     if(!gyVmuFlashFileRead((EvmuDevice*)dev, entry, vms, 1)) {
@@ -899,8 +908,6 @@ int gyVmuFlashExportDci(const EvmuDevice* dev, const EvmuDirEntry* entry, const 
         goto free_img;
     }
 
-    size_t bytesToWrite   = dataSize;// + sizeof(EvmuDirEntry);
-
     FILE* fp = fopen(path, "wb");
     if(/*!retVal ||*/ !fp) {
         strncpy(_lastErrorMsg, "Failed to create the file!", sizeof(_lastErrorMsg));
@@ -909,9 +916,9 @@ int gyVmuFlashExportDci(const EvmuDevice* dev, const EvmuDirEntry* entry, const 
         goto free_img;
     }
 
-    EvmuNexus_applyByteOrdering(vms, dataSize);
+    EvmuNexus_applyByteOrdering(vms, paddedFileSize);
 
-    if(!fwrite(data, 1, bytesToWrite, fp)) {
+    if(fwrite(data, 1, bytesToWrite, fp) != bytesToWrite) {
         strncpy(_lastErrorMsg, "Failed to write all bytes to the file.", sizeof(_lastErrorMsg));
         EVMU_LOG_ERROR("%s", _lastErrorMsg);
         success = 0;

--- a/lib/source/fs/evmu_vmi.c
+++ b/lib/source/fs/evmu_vmi.c
@@ -197,16 +197,24 @@ EVMU_EXPORT EVMU_RESULT EvmuVmi_fromVmsFile(EvmuVmi*    pSelf,
     EVMU_LOG_INFO("Attempting to generating VMI from raw VMS file.");
     EVMU_LOG_PUSH();
 
-    EVMU_FILE_TYPE fileType = EvmuVms_guessFileType(pData);
-    if(fileType != EVMU_FILE_TYPE_DATA)
+    EVMU_FILE_TYPE fileType = EVMU_FILE_TYPE_NONE;
+
+    if(bytes >= sizeof(EvmuVms))
+        fileType = EvmuVms_guessFileType(pData);
+
+    if(fileType != EVMU_FILE_TYPE_DATA &&
+       bytes >= EVMU_FAT_BLOCK_SIZE + sizeof(EvmuVms))
+    {
         fileType = EvmuVms_guessFileType(GBL_PTR_OFFSET(const EvmuVms*, pData, EVMU_FAT_BLOCK_SIZE));
+    }
 
     GBL_CTX_VERIFY(fileType != EVMU_FILE_TYPE_NONE,
                    EVMU_RESULT_ERROR_INVALID_FILE,
                    "Failed to automatically determine file type!");
 
-    EvmuVms* pVms = (EvmuVms*)(fileType == EVMU_FILE_TYPE_DATA?
-                               pData : GBL_PTR_OFFSET(pData, EVMU_FAT_BLOCK_SIZE));
+    const EvmuVms* pVms = fileType == EVMU_FILE_TYPE_DATA?
+                          (const EvmuVms*)pData :
+                          GBL_PTR_OFFSET(const EvmuVms*, pData, EVMU_FAT_BLOCK_SIZE);
 
 
     memset(pSelf, 0, sizeof(EvmuVmi));

--- a/lib/source/fs/evmu_vms.c
+++ b/lib/source/fs/evmu_vms.c
@@ -147,10 +147,20 @@ EVMU_EXPORT const void* EvmuVms_icon(const EvmuVms* pSelf, size_t index) {
 
 EVMU_EXPORT uint16_t EvmuVms_computeCrc(const EvmuVms* pSelf) {
     uint16_t crc = 0;
-    uint16_t oldCrc = pSelf->crc;
-    ((EvmuVms*)pSelf)->crc = 0;
-    crc = gblHashCrc16BitPartial(pSelf, EvmuVms_totalBytes(pSelf), &crc);
-    ((EvmuVms*)pSelf)->crc = oldCrc;
+    EvmuVms header = *pSelf;
+    const size_t totalBytes = EvmuVms_totalBytes(pSelf);
+
+    // Zero the CRC in a local header copy so the caller's buffer stays untouched.
+    header.crc = 0;
+    crc = gblHashCrc16BitPartial(&header, sizeof(header), &crc);
+
+    // Then hash the bytes after the fixed VMS header.
+    if(totalBytes > sizeof(EvmuVms)) {
+        crc = gblHashCrc16BitPartial(((const uint8_t*)pSelf) + sizeof(EvmuVms),
+                                     totalBytes - sizeof(EvmuVms),
+                                     &crc);
+    }
+
     return crc;
 }
 

--- a/lib/source/fs/evmu_vms.c
+++ b/lib/source/fs/evmu_vms.c
@@ -240,7 +240,10 @@ EVMU_EXPORT GblRingList* EvmuVms_createIconsArgb4444(const EvmuVms* pSelf) {
     EVMU_LOG_PUSH();
 
     for(size_t i = 0 ; i < pSelf->iconCount; ++i) {
-        GblByteArray*  pByteArray = GblByteArray_create(EVMU_VMS_ICON_BITMAP_SIZE);
+        GblByteArray*  pByteArray =
+            GblByteArray_create(sizeof(uint16_t) *
+                                EVMU_VMS_ICON_BITMAP_WIDTH *
+                                EVMU_VMS_ICON_BITMAP_HEIGHT);
         const uint8_t* pImage     = EvmuVms_icon(pSelf, i);
 
         for(size_t b = 0; b < EVMU_VMS_ICON_BITMAP_SIZE * 2; ++b) {

--- a/lib/source/fs/evmu_vms.c
+++ b/lib/source/fs/evmu_vms.c
@@ -121,17 +121,22 @@ EVMU_EXPORT void EvmuVms_log(const EvmuVms* pSelf) {
 }
 
 EVMU_EXPORT EVMU_FILE_TYPE EvmuVms_guessFileType(const EvmuVms* pSelf) {
-    if(EvmuVms_isValid(pSelf) &&
-       pSelf->crc             &&
-       pSelf->dataBytes == EvmuVms_totalBytes(pSelf) - EvmuVms_headerBytes(pSelf)
-      )
-        return EVMU_FILE_TYPE_DATA;
+    const size_t maxFileBytes =
+        EVMU_FAT_BLOCK_USERDATA_SIZE_DEFAULT * EVMU_FAT_BLOCK_SIZE;
+
+    if(!EvmuVms_isValid(pSelf))
+        return EVMU_FILE_TYPE_NONE;
+
+    // DATA files store a real payload size in dataBytes, so reject DATA files
+    // that claim more bytes than a standard VMU can hold.
+    if(pSelf->crc)
+        return EvmuVms_totalBytes(pSelf) <= maxFileBytes ?
+               EVMU_FILE_TYPE_DATA :
+               EVMU_FILE_TYPE_NONE;
+
     // Relaxed: ignore dataBytes for GAME detection, since production games
     // like Shenmue and NanwakaDensetsu set dataBytes in their GAME headers.
-    else if(EvmuVms_isValid(pSelf) && !pSelf->crc)
-        return EVMU_FILE_TYPE_GAME;
-    else
-        return EVMU_FILE_TYPE_NONE;
+    return EVMU_FILE_TYPE_GAME;
 }
 
 EVMU_EXPORT const void* EvmuVms_eyecatch(const EvmuVms* pSelf) {

--- a/lib/source/fs/evmu_vms.c
+++ b/lib/source/fs/evmu_vms.c
@@ -202,7 +202,10 @@ EVMU_EXPORT GblByteArray* EvmuVms_createEyecatchArgb4444(const EvmuVms* pSelf) {
 
             for(size_t b = 0; b < EVMU_VMS_EYECATCH_BITMAP_SIZE_COLOR_256; ++b) {
                 GBL_CTX_VERIFY_CALL(
-                    GblByteArray_write(pByteArray, 0, sizeof(uint16_t), &pPalette[pImage[b]])
+                    GblByteArray_write(pByteArray,
+                                       b * sizeof(uint16_t),
+                                       sizeof(uint16_t),
+                                       &pPalette[pImage[b]])
                 );
             }
         } else if(pSelf->eyecatchType == EVMU_VMS_EYECATCH_PALETTE_16) {
@@ -212,7 +215,10 @@ EVMU_EXPORT GblByteArray* EvmuVms_createEyecatchArgb4444(const EvmuVms* pSelf) {
                 const uint8_t palIndex = b % 2? pImage[b / 2] & 0xf : (pImage[b / 2] >> 4) & 0xf;
 
                 GBL_CTX_VERIFY_CALL(
-                    GblByteArray_write(pByteArray, 0, sizeof(uint16_t), &pPalette[palIndex])
+                    GblByteArray_write(pByteArray,
+                                       b * sizeof(uint16_t),
+                                       sizeof(uint16_t),
+                                       &pPalette[palIndex])
                 );
             }
         } else GBL_ASSERT(GBL_FALSE, "Unknown VMS eyecatch type!");
@@ -250,7 +256,10 @@ EVMU_EXPORT GblRingList* EvmuVms_createIconsArgb4444(const EvmuVms* pSelf) {
             const uint8_t palIndex = b % 2? pImage[b / 2] & 0xf : (pImage[b / 2] >> 4) & 0xf;
 
             GBL_CTX_CALL(
-                GblByteArray_write(pByteArray, 0, sizeof(uint16_t), &pSelf->palette[palIndex])
+                GblByteArray_write(pByteArray,
+                                   b * sizeof(uint16_t),
+                                   sizeof(uint16_t),
+                                   &pSelf->palette[palIndex])
             );
         }
 

--- a/lib/source/hw/evmu_lcd.c
+++ b/lib/source/hw/evmu_lcd.c
@@ -147,13 +147,13 @@ EVMU_EXPORT void EvmuLcd_setPixel(EvmuLcd* pSelf, size_t x, size_t y, GblBool on
     xramBitFromRowCol_(x, y, &bank, &addr, &bit);
     addr -= 0x180;
 
-    int prevVal = pSelf_->pRam->xram[bank][addr] & (0x1<<bit);
+    const GblBool wasOn = (pSelf_->pRam->xram[bank][addr] & (0x1 << bit)) != 0;
 
-    if(on != prevVal) {
+    if(on != wasOn) {
         if(on) {
-            pSelf_->pRam->xram[bank][addr] |= (0x1<<bit);
+            pSelf_->pRam->xram[bank][addr] |= (0x1 << bit);
         } else {
-            pSelf_->pRam->xram[bank][addr] &= ~(0x1<<bit);
+            pSelf_->pRam->xram[bank][addr] &= ~(0x1 << bit);
         }
 
         pSelf->screenChanged = GBL_TRUE;
@@ -306,7 +306,9 @@ EVMU_EXPORT GblBool EvmuLcd_refreshEnabled(const EvmuLcd* pSelf) {
 
 EVMU_EXPORT void EvmuLcd_setRefreshEnabled(EvmuLcd* pSelf, GblBool enabled) {
     EvmuLcd_* pSelf_ = EVMU_LCD_(pSelf);
-    int wasEnabled =  pSelf_->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_MCR)] & EVMU_SFR_MCR_MCR3_MASK;
+    const GblBool wasEnabled =
+        (pSelf_->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_MCR)] &
+         EVMU_SFR_MCR_MCR3_MASK) != 0;
 
     if(enabled != wasEnabled) {
         if(enabled) {


### PR DESCRIPTION
- Fix `EvmuLcd_setPixel()` and `EvmuLcd_setRefreshEnabled()` so they compare normalized booleans instead of raw bitmasks.
- Make `EvmuVms_computeCrc()` const-correct by hashing a local header copy with `crc = 0` instead of temporarily mutating the caller buffer.
- Fix `EvmuVms_guessFileType()` so DATA validation is no longer tautological and rejects obviously impossible oversized DATA headers.
- Guard `EvmuVmi_fromVmsFile()` against truncated inputs before probing for DATA/GAME headers.
- Fix ARGB4444 extraction for VMS icons and paletted eyecatches:
  - allocate icon output buffers at the real decoded size
  - write decoded pixels to their proper destination offsets instead of always offset `0`
- Fix DCI export buffer sizing in `gyVmuFlashExportDci()` by calculating padding explicitly instead of relying on a broken ternary expression.
- Fix the same DCI export path to apply Nexus byte ordering to the payload length, not past the payload buffer.