### PR TITLE
Clock api fixes

### DIFF
--- a/lib/source/hw/evmu_clock.c
+++ b/lib/source/hw/evmu_clock.c
@@ -282,7 +282,7 @@ GBL_EXPORT EVMU_RESULT EvmuClock_setSystemState(const EvmuClock* pSelf, EVMU_CLO
 
     switch(state) {
     case EVMU_CLOCK_SYSTEM_STATE_HOLD:
-        pcon |= EVMU_SFR_PCON_HOLD_MASK | EVMU_SFR_PCON_HALT_MASK;
+        pcon |= EVMU_SFR_PCON_HOLD_MASK;
         break;
     case EVMU_CLOCK_SYSTEM_STATE_HALT:
         pcon |= EVMU_SFR_PCON_HALT_MASK;
@@ -291,7 +291,9 @@ GBL_EXPORT EVMU_RESULT EvmuClock_setSystemState(const EvmuClock* pSelf, EVMU_CLO
         break;
     }
 
-    EVMU_CLOCK_(pSelf)->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_PCON)] = pcon;
+    EvmuRam_writeData(EVMU_RAM_PUBLIC_(EVMU_CLOCK_(pSelf)->pRam),
+                      EVMU_ADDRESS_SFR_PCON,
+                      pcon);
     GBL_CTX_END();
 }
 

--- a/lib/source/hw/evmu_clock.c
+++ b/lib/source/hw/evmu_clock.c
@@ -81,6 +81,12 @@ static EVMU_OSCILLATOR EvmuClock_oscillatorFromOcr_(EvmuWord ocr) {
     }
 }
 
+static EVMU_CLOCK_DIVIDER EvmuClock_dividerFromOcr_(EvmuWord ocr) {
+    return (ocr & EVMU_SFR_OCR_OCR7_MASK)?
+                EVMU_CLOCK_DIVIDER_6 :
+                EVMU_CLOCK_DIVIDER_12;
+}
+
 static EvmuTicks EvmuClock_ticksPerCycle_(EVMU_OSCILLATOR oscillator, GblBool div6) {
     switch(oscillator) {
     case EVMU_OSCILLATOR_CF:
@@ -183,91 +189,83 @@ EVMU_EXPORT EVMU_RESULT EvmuClock_oscillatorSpecs(const EvmuClock* pSelf, EVMU_O
 
 GBL_EXPORT GblBool EvmuClock_oscillatorActive(const EvmuClock* pSelf, EVMU_OSCILLATOR oscillator) {
     GblBool active = GBL_FALSE;
-#if 0
     GBL_CTX_BEGIN(pSelf);
     GBL_CTX_VERIFY_POINTER(pSelf);
     GBL_CTX_VERIFY_ARG(oscillator < EVMU_OSCILLATOR_COUNT);
 
+    const EvmuWord ocr = EVMU_CLOCK_(pSelf)->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_OCR)];
+    const EvmuWord pcon = EVMU_CLOCK_(pSelf)->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_PCON)];
+
+    // HOLD stops every oscillator regardless of the OCR enable bits.
+    if(pcon & EVMU_SFR_PCON_HOLD_MASK) {
+        GBL_CTX_DONE();
+        goto end;
+    }
+
     switch(oscillator) {
     case EVMU_OSCILLATOR_QUARTZ:
-        /*THIS IS ABSOLUTELY WRONG, VMU after reset has Quartz disabled, then BIOS enables it.
-         * There must be a control register somewhere for it. Perhaps OCR.2? */
         active = GBL_TRUE;
         break;
     case EVMU_OSCILLATOR_RC:
-        active = !EvmuRam__sfrMaskTest_(EVMU_CLOCK_(pSelf)->pRam,
-                                           EVMU_ADDRESS_SFR_OCR,
-                                           EVMU_SFR_OCR_OCR1_MASK);
+        active = (ocr & EVMU_SFR_OCR_OCR1_MASK) == 0;
         break;
     case EVMU_OSCILLATOR_CF:
-        active = !EvmuRam__sfrMaskTest_(EVMU_CLOCK_(pSelf)->pRam,
-                                           EVMU_ADDRESS_SFR_OCR,
-                                           EVMU_SFR_OCR_OCR0_MASK);
+        active = (ocr & EVMU_SFR_OCR_OCR0_MASK) == 0;
         break;
     }
 
+end:
     GBL_CTX_END_BLOCK();
-#endif
     return active;
 }
 
 GBL_EXPORT GBL_RESULT EvmuClock_setOscillatorActive(const EvmuClock* pSelf, EVMU_OSCILLATOR oscillator, GblBool active) {
     GBL_CTX_BEGIN(pSelf);
-#if 0
     GBL_CTX_VERIFY_POINTER(pSelf);
     GBL_CTX_VERIFY_ARG(oscillator < EVMU_OSCILLATOR_COUNT);
 
+    EvmuWord ocr = EVMU_CLOCK_(pSelf)->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_OCR)];
+
     switch(oscillator) {
     case EVMU_OSCILLATOR_QUARTZ:
-        /*THIS IS ABSOLUTELY WRONG, VMU after reset has Quartz disabled, then BIOS enables it.
-         * There must be a control register somewhere for it. Perhaps OCR.2? */
-        EVMU_PERIPHERAL_WARNING("Cannot activate/deactivate Quartz oscillator! (automatic in bios)");
+        GBL_CTX_VERIFY(active,
+                       GBL_RESULT_ERROR_INVALID_OPERATION,
+                       "Quartz oscillator cannot be disabled through OCR");
         break;
     case EVMU_OSCILLATOR_RC:
         if(active)
-            EvmuRam__sfrMaskClear_(EVMU_CLOCK_(pSelf)->pRam,
-                                      EVMU_ADDRESS_SFR_OCR,
-                                      EVMU_SFR_OCR_OCR1_MASK);
+            ocr &= (EvmuWord)~EVMU_SFR_OCR_OCR1_MASK;
         else
-            EvmuRam__sfrMaskSet_(EVMU_CLOCK_(pSelf)->pRam,
-                                      EVMU_ADDRESS_SFR_OCR,
-                                      EVMU_SFR_OCR_OCR1_MASK);
+            ocr |= EVMU_SFR_OCR_OCR1_MASK;
         break;
     case EVMU_OSCILLATOR_CF:
         if(active)
-            EvmuRam__sfrMaskClear_(EVMU_CLOCK_(pSelf)->pRam,
-                                      EVMU_ADDRESS_SFR_OCR,
-                                      EVMU_SFR_OCR_OCR0_MASK);
+            ocr &= (EvmuWord)~EVMU_SFR_OCR_OCR0_MASK;
         else
-            EvmuRam__sfrMaskSet_(EVMU_CLOCK_(pSelf)->pRam,
-                                    EVMU_ADDRESS_SFR_OCR,
-                                    EVMU_SFR_OCR_OCR0_MASK);
+            ocr |= EVMU_SFR_OCR_OCR0_MASK;
         break;
     }
-#endif
+
+    EVMU_CLOCK_(pSelf)->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_OCR)] = ocr;
     GBL_CTX_END();
 }
 
 GBL_EXPORT EVMU_CLOCK_SYSTEM_STATE EvmuClock_systemState(const EvmuClock* pSelf) GBL_NOEXCEPT {
     EVMU_CLOCK_SYSTEM_STATE state = EVMU_CLOCK_SYSTEM_STATE_UNKNOWN;
     GBL_CTX_BEGIN(pSelf);
-#if 0
     GBL_CTX_VERIFY_POINTER(pSelf);
 
-    if(EvmuRam__sfrMaskTest_(EVMU_CLOCK_(pSelf)->pRam,
-                                EVMU_ADDRESS_SFR_PCON,
-                                EVMU_SFR_PCON_HOLD_MASK))
+    const EvmuWord pcon = EVMU_CLOCK_(pSelf)->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_PCON)];
+
+    if(pcon & EVMU_SFR_PCON_HOLD_MASK)
     {
         state = EVMU_CLOCK_SYSTEM_STATE_HOLD;
-    } else if(EvmuRam__sfrMaskTest_(EVMU_CLOCK_(pSelf)->pRam,
-                                       EVMU_ADDRESS_SFR_PCON,
-                                       EVMU_SFR_PCON_HALT_MASK))
+    } else if(pcon & EVMU_SFR_PCON_HALT_MASK)
     {
         state = EVMU_CLOCK_SYSTEM_STATE_HALT;
     } else {
         state = EVMU_CLOCK_SYSTEM_STATE_RUNNING;
     }
-#endif
     GBL_CTX_END_BLOCK();
     return state;
 }
@@ -278,33 +276,22 @@ GBL_EXPORT EVMU_RESULT EvmuClock_setSystemState(const EvmuClock* pSelf, EVMU_CLO
     GBL_CTX_VERIFY_POINTER(pSelf);
     GBL_CTX_VERIFY_ARG(state != EVMU_CLOCK_SYSTEM_STATE_UNKNOWN &&
                        state < EVMU_CLOCK_SYSTEM_STATE_COUNT);
-#if 0
 
-    if(state == EVMU_CLOCK_SYSTEM_STATE_HOLD) {
-        EvmuRam__sfrMaskSet_(EVMU_CLOCK_(pSelf)->pRam,
-                                EVMU_ADDRESS_SFR_PCON,
-                                EVMU_SFR_PCON_HOLD_MASK);
-        EvmuRam__sfrMaskSet_(EVMU_CLOCK_(pSelf)->pRam,
-                                EVMU_ADDRESS_SFR_PCON,
-                                EVMU_SFR_PCON_HALT_MASK);
+    EvmuWord pcon = EVMU_CLOCK_(pSelf)->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_PCON)];
+    pcon &= (EvmuWord)~(EVMU_SFR_PCON_HOLD_MASK | EVMU_SFR_PCON_HALT_MASK);
 
-    } else if(state == EVMU_CLOCK_SYSTEM_STATE_HALT) {
-        EvmuRam__sfrMaskClear_(EVMU_CLOCK_(pSelf)->pRam,
-                                  EVMU_ADDRESS_SFR_PCON,
-                                  EVMU_SFR_PCON_HOLD_MASK);
-        EvmuRam__sfrMaskSet_(EVMU_CLOCK_(pSelf)->pRam,
-                                EVMU_ADDRESS_SFR_PCON,
-                                EVMU_SFR_PCON_HALT_MASK);
-
-    } else {
-        EvmuRam__sfrMaskClear_(EVMU_CLOCK_(pSelf)->pRam,
-                                  EVMU_ADDRESS_SFR_PCON,
-                                  EVMU_SFR_PCON_HOLD_MASK);
-        EvmuRam__sfrMaskClear_(EVMU_CLOCK_(pSelf)->pRam,
-                                  EVMU_ADDRESS_SFR_PCON,
-                                  EVMU_SFR_PCON_HALT_MASK);
+    switch(state) {
+    case EVMU_CLOCK_SYSTEM_STATE_HOLD:
+        pcon |= EVMU_SFR_PCON_HOLD_MASK | EVMU_SFR_PCON_HALT_MASK;
+        break;
+    case EVMU_CLOCK_SYSTEM_STATE_HALT:
+        pcon |= EVMU_SFR_PCON_HALT_MASK;
+        break;
+    default:
+        break;
     }
-#endif
+
+    EVMU_CLOCK_(pSelf)->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_PCON)] = pcon;
     GBL_CTX_END();
 }
 
@@ -314,31 +301,9 @@ GBL_EXPORT EVMU_RESULT EvmuClock_systemConfig(const EvmuClock* pSelf, EVMU_OSCIL
     GBL_CTX_VERIFY_POINTER(pSource);
     GBL_CTX_VERIFY_POINTER(pDivider);
 
-#if 0
-
-    if(EvmuRam__sfrMaskTest_(EVMU_CLOCK_(pSelf)->pRam,
-                                EVMU_ADDRESS_SFR_OCR,
-                                EVMU_SFR_OCR_OCR4_MASK))  {
-        *pSource    = EVMU_OSCILLATOR_CF;
-        *pDivider   = EVMU_CLOCK_DIVIDER_1;
-
-    } else if(EvmuRam__sfrMaskTest_(EVMU_CLOCK_(pSelf)->pRam,
-                                       EVMU_ADDRESS_SFR_OCR,
-                                       EVMU_SFR_OCR_OCR5_MASK)) {
-        *pSource = EVMU_OSCILLATOR_QUARTZ;
-        *pDivider = EvmuRam__sfrMaskTest_(EVMU_CLOCK_(pSelf)->pRam,
-                                             EVMU_ADDRESS_SFR_OCR,
-                                             EVMU_SFR_OCR_OCR7_MASK) ?
-                        EVMU_CLOCK_DIVIDER_6 : EVMU_CLOCK_DIVIDER_12;
-    } else {
-        *pSource = EVMU_OSCILLATOR_RC;
-        *pDivider = EvmuRam__sfrMaskTest_(EVMU_CLOCK_(pSelf)->pRam,
-                                             EVMU_ADDRESS_SFR_OCR,
-                                             EVMU_SFR_OCR_OCR7_MASK) ?
-                        EVMU_CLOCK_DIVIDER_6 : EVMU_CLOCK_DIVIDER_12;
-
-    }
-#endif
+    const EvmuWord ocr = EVMU_CLOCK_(pSelf)->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_OCR)];
+    *pSource  = EvmuClock_oscillatorFromOcr_(ocr);
+    *pDivider = EvmuClock_dividerFromOcr_(ocr);
     GBL_CTX_END();
 }
 
@@ -348,41 +313,30 @@ GBL_EXPORT EVMU_RESULT EvmuClock_setSystemConfig(const EvmuClock* pSelf, EVMU_OS
     GBL_CTX_VERIFY_ARG(source < EVMU_OSCILLATOR_COUNT);
     GBL_CTX_VERIFY_ARG(divider < EVMU_CLOCK_DIVIDER_COUNT);
 
-#if 0
+    GBL_CTX_VERIFY_ARG(divider != EVMU_CLOCK_DIVIDER_1,
+                       "Only valid system clock dividers are 1/6 and 1/12!");
 
-    if(source == EVMU_OSCILLATOR_CF) {
-        GBL_CTX_VERIFY_ARG(divider == EVMU_CLOCK_DIVIDER_1,
-                           "Cannot set clock divider with CF oscillator!");
-        GBL_CTX_CALL(EvmuClock_setOscillatorActive(pSelf, EVMU_OSCILLATOR_CF, GBL_TRUE));
-        EvmuRam__sfrMaskSet_(EVMU_CLOCK_(pSelf)->pRam,
-                                EVMU_ADDRESS_SFR_OCR,
-                                EVMU_SFR_OCR_OCR4_MASK);
-    } else {
-        GBL_CTX_VERIFY_ARG(divider != EVMU_CLOCK_DIVIDER_1,
-                           "Only valid dividers for RC/Quartz osillators are 1/6 and 1/12!");
+    EvmuWord ocr = EVMU_CLOCK_(pSelf)->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_OCR)];
 
-        if(divider == EVMU_CLOCK_DIVIDER_12)
-            EvmuRam__sfrMaskClear_(EVMU_CLOCK_(pSelf)->pRam,
-                                      EVMU_ADDRESS_SFR_OCR,
-                                      EVMU_SFR_OCR_OCR7_MASK);
-        else
-            EvmuRam__sfrMaskSet_(EVMU_CLOCK_(pSelf)->pRam,
-                                    EVMU_ADDRESS_SFR_OCR,
-                                    EVMU_SFR_OCR_OCR7_MASK);
+    ocr &= (EvmuWord)~(EVMU_SFR_OCR_OCR7_MASK |
+                       EVMU_SFR_OCR_OCR5_MASK |
+                       EVMU_SFR_OCR_OCR4_MASK);
 
-        GBL_CTX_CALL(EvmuClock_setOscillatorActive(pSelf, source, GBL_TRUE));
+    if(divider == EVMU_CLOCK_DIVIDER_6)
+        ocr |= EVMU_SFR_OCR_OCR7_MASK;
 
-        if(source == EVMU_OSCILLATOR_RC)
-            EvmuRam__sfrMaskClear_(EVMU_CLOCK_(pSelf)->pRam,
-                                    EVMU_ADDRESS_SFR_OCR,
-                                    EVMU_SFR_OCR_OCR5_MASK);
-        else // source == Quartz
-            EvmuRam__sfrMaskSet_(EVMU_CLOCK_(pSelf)->pRam,
-                                    EVMU_ADDRESS_SFR_OCR,
-                                    EVMU_SFR_OCR_OCR5_MASK);
-
+    switch(source) {
+    case EVMU_OSCILLATOR_CF:
+        ocr |= EVMU_SFR_OCR_OCR4_MASK;
+        break;
+    case EVMU_OSCILLATOR_QUARTZ:
+        ocr |= EVMU_SFR_OCR_OCR5_MASK;
+        break;
+    default:
+        break;
     }
-#endif
+
+    EVMU_CLOCK_(pSelf)->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_OCR)] = ocr;
     GBL_CTX_END();
 }
 

--- a/lib/source/hw/evmu_cpu.c
+++ b/lib/source/hw/evmu_cpu.c
@@ -68,9 +68,11 @@ EVMU_EXPORT double EvmuCpu_secs(const EvmuCpu* pSelf) {
     EvmuCpu_*    pSelf_  = EVMU_CPU_(pSelf);
     EvmuRam_* pRam = pSelf_->pRam;
     EvmuClock*   pClock  = EvmuPeripheral_device(EVMU_PERIPHERAL(pSelf))->pClock;
+    const EvmuWord pcon =
+        pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_PCON)];
 
     return EvmuClock_systemSecsPerCycle(pClock) *
-            ((!(pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_PCON)] & EVMU_SFR_PCON_HALT_MASK))?
+            (((pcon & (EVMU_SFR_PCON_HALT_MASK | EVMU_SFR_PCON_HOLD_MASK)) == 0)?
             (double)EvmuIsa_format(pSelf_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE])->cc : 1.0);
 
 }
@@ -583,14 +585,23 @@ static EVMU_RESULT EvmuCpu_IBehavior_update_(EvmuIBehavior* pIBehav, EvmuTicks t
     EvmuIBehavior_update(EVMU_IBEHAVIOR(pDevice->pGamepad), ticks);
 
     while(time < deltaTime) {
-        EvmuPic_update(EVMU_PIC_PUBLIC_(pDevice_->pPic));
-        EvmuTimers_update(EVMU_TIMERS_PUBLIC_(pDevice_->pTimers));
-        if(!(pDevice_->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_PCON)] & EVMU_SFR_PCON_HALT_MASK))
+        const EvmuWord pcon =
+            pDevice_->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_PCON)];
+        const GblBool hold = (pcon & EVMU_SFR_PCON_HOLD_MASK) != 0;
+        const GblBool halt = (pcon & EVMU_SFR_PCON_HALT_MASK) != 0;
+
+        if(!hold) {
+            EvmuPic_update(EVMU_PIC_PUBLIC_(pDevice_->pPic));
+            EvmuTimers_update(EVMU_TIMERS_PUBLIC_(pDevice_->pTimers));
+        }
+
+        if(!halt && !hold)
             EvmuCpu_runNext(pSelf);
 
         const double cpuTime = EvmuCpu_secs(pSelf);
         time += cpuTime;
-        EvmuIBehavior_update(EVMU_IBEHAVIOR(pDevice->pLcd), cpuTime*1000000.0);
+        if(!hold)
+            EvmuIBehavior_update(EVMU_IBEHAVIOR(pDevice->pLcd), cpuTime*1000000.0);
 
     }
 

--- a/lib/source/hw/evmu_gamepad.c
+++ b/lib/source/hw/evmu_gamepad.c
@@ -38,9 +38,14 @@ static EVMU_RESULT EvmuGamepad_pollButtons_(EvmuGamepad* pSelf) {
         // Check whether interrupt generation is enabled
         if(p3Int & EVMU_SFR_P3INT_P32INT_MASK) {
             // Set interrupt source to P3
-            pSelf_->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_P3INT)] |= EVMU_SFR_P3INT_P31INT_MASK;
+            EvmuRam_writeData(EVMU_RAM_PUBLIC_(pSelf_->pRam),
+                              EVMU_ADDRESS_SFR_P3INT,
+                              p3Int | EVMU_SFR_P3INT_P31INT_MASK);
             // Break out of HOLD mode
-            pSelf_->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_PCON)] &= ~EVMU_SFR_PCON_HOLD_MASK;
+            EvmuRam_writeData(EVMU_RAM_PUBLIC_(pSelf_->pRam),
+                              EVMU_ADDRESS_SFR_PCON,
+                              pSelf_->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_PCON)] &
+                                  (EvmuWord)~EVMU_SFR_PCON_HOLD_MASK);
             // Check if interrupt should be handled
             if(p3Int & EVMU_SFR_P3INT_P30INT_MASK) {
                 // Submit IRQ to PIC

--- a/lib/source/hw/evmu_lcd.c
+++ b/lib/source/hw/evmu_lcd.c
@@ -233,9 +233,16 @@ static float samplePixel_(const EvmuLcd* pSelf, size_t x, size_t y) {
 }
 
 EVMU_EXPORT uint8_t EvmuLcd_decoratedPixel(const EvmuLcd* pSelf, size_t x, size_t y) {
+    EvmuLcd_* pSelf_ = EVMU_LCD_(pSelf);
     GBL_ASSERT(x < EVMU_LCD_PIXEL_WIDTH && y < EVMU_LCD_PIXEL_HEIGHT);
 
-    // Powering down the LCD blanks the visible output to white
+    // HOLD stops the LCD driver clock, so the panel loses its visible image
+    // even though the stored XRAM contents remain intact.
+    if((pSelf_->pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_PCON)] &
+        EVMU_SFR_PCON_HOLD_MASK) != 0)
+        return 255;
+
+    // Powering down the LCD also blanks the visible output to white.
     if(!EvmuLcd_screenEnabled(pSelf))
         return 255;
 

--- a/lib/source/hw/evmu_ram.c
+++ b/lib/source/hw/evmu_ram.c
@@ -8,6 +8,8 @@
 #include "evmu_rom_.h"
 #include <gimbal/utils/gimbal_date_time.h>
 
+#define EVMU_RAM__OCR_READBACK_HIGH_MASK_ 0x4c
+
 EVMU_EXPORT EvmuAddress EvmuRam_indirectAddress(const EvmuRam* pSelf, size_t mode) {
     EvmuAddress value = 0;
     GBL_CTX_BEGIN(pSelf);
@@ -105,6 +107,11 @@ EVMU_EXPORT EvmuWord EvmuRam_readData(const EvmuRam* pSelf, EvmuAddress addr) {
         GBL_CTX_DONE();
     case EVMU_ADDRESS_SFR_P7:
         value = 0xf0|(pSelf_->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_P7)]);
+        GBL_CTX_DONE();
+    case EVMU_ADDRESS_SFR_OCR:
+        // Hardware reads back 1 for OCR's undocumented H bits (6, 3, and 2).
+        value = EVMU_RAM__OCR_READBACK_HIGH_MASK_ |
+                pSelf_->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_OCR)];
         GBL_CTX_DONE();
     default: {
         GBL_CTX_VERIFY(addr/EVMU_RAM__INT_SEGMENT_SIZE_ < EVMU_RAM__INT_SEGMENT_COUNT_,

--- a/lib/source/hw/evmu_ram.c
+++ b/lib/source/hw/evmu_ram.c
@@ -306,8 +306,10 @@ EVMU_EXPORT EVMU_RESULT EvmuRam_writeData(EvmuRam* pSelf, EvmuAddress addr, Evmu
         break;
     }
     case EVMU_ADDRESS_SFR_PCON:
-     //   GBL_CTX_VERBOSE("PCON: %x", val);
-    default: break;
+        if(((pSelf_->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_PCON)] ^ val) &
+            EVMU_SFR_PCON_HOLD_MASK) != 0)
+            pDevice->pLcd->screenChanged = GBL_TRUE;
+     default: break;
     }
 
     GBL_CTX_VERIFY(addr/EVMU_RAM__INT_SEGMENT_SIZE_ < EVMU_RAM__INT_SEGMENT_COUNT_,


### PR DESCRIPTION
This PR fixes three related clock/power-model issues in `libevmu`:

1. Restores the public clock configuration/state APIs so they reflect and update real OCR/PCON-backed state instead of returning stubbed defaults.
2. Fixes raw OCR readback to match observed hardware behavior, including the always-high readback bits.
3. Makes HOLD-mode side effects consistent across the clock, CPU, timers, LCD, RAM, and input wakeup paths.

## What changed

### Clock API fixes
- Re-enabled the OCR/PCON-backed logic in `EvmuClock` APIs.
- `EvmuClock_systemConfig()` now decodes the active source/divider from OCR instead of returning bogus success.
- `EvmuClock_setSystemConfig()` updates OCR and rejects invalid configurations.
- `EvmuClock_systemState()` / `EvmuClock_setSystemState()` now reflect and update PCON correctly.
- Oscillator active-state getters/setters now reflect the actual OCR control bits.

### OCR readback parity
- Preserved the stored OCR control bits used by the emulator’s clock logic.
- Updated raw SFR readback so OCR reports the observed hardware-high bits in positions 6, 3, and 2.
- This brings `EvmuRam_readData(OCR)` in line with hardware probes while keeping masked clock control behavior unchanged.

### HOLD-mode behavior
- Treated HOLD separately from HALT instead of collapsing them together.
- PCON writes now flow through `EvmuRam_writeData()` so side effects are applied consistently.
- CPU execution, timer/PIC advancement, and LCD visibility now respect HOLD-mode behavior.
- Gamepad wakeup clears HOLD through the RAM write path and updates interrupt state consistently.
- LCD output now blanks while held, while preserving the stored LCD/XRAM contents.
