### PR TITLE
Implement BTCR-driven Base Timer emulation

### DIFF
--- a/lib/source/hw/evmu_ram.c
+++ b/lib/source/hw/evmu_ram.c
@@ -229,6 +229,7 @@ EVMU_EXPORT EVMU_RESULT EvmuRam_writeData(EvmuRam* pSelf, EvmuAddress addr, Evmu
     case EVMU_ADDRESS_SFR_T0PRR:
         pDev_->pTimers->timer0.tscale = 256 - val;
         pDev_->pTimers->timer0.tbase  = 0;
+        pDev_->pTimers->baseTimer.tickRemainder = 0;
         break;
     case EVMU_ADDRESS_SFR_T0CNT:
     {
@@ -292,6 +293,30 @@ EVMU_EXPORT EVMU_RESULT EvmuRam_writeData(EvmuRam* pSelf, EvmuAddress addr, Evmu
     case EVMU_ADDRESS_SFR_T1HR:
         if(!(pSelf_->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_T1CNT)]&EVMU_SFR_T1CNT_T1HRUN_MASK))
             pDev_->pTimers->timer1.base.th = val;
+        break;
+    case EVMU_ADDRESS_SFR_BTCR:
+    {
+        const EvmuWord prevVal =
+            pSelf_->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_BTCR)];
+        const GblBool wasRunning =
+            (prevVal & EVMU_SFR_BTCR_OP_CTRL_MASK) != 0;
+        const GblBool isRunning =
+            (val & EVMU_SFR_BTCR_OP_CTRL_MASK) != 0;
+
+        if(!wasRunning && isRunning)
+            pDev_->pTimers->baseTimer.startDelayCycles =
+                (unsigned)EvmuCpu_cycles(pDevice->pCpu);
+        else if(!isRunning)
+            pDev_->pTimers->baseTimer.startDelayCycles = 0;
+
+        if(!isRunning)
+            pDev_->pTimers->baseTimer.counter = 0;
+
+        break;
+    }
+    case EVMU_ADDRESS_SFR_ISL:
+    case EVMU_ADDRESS_SFR_OCR:
+        pDev_->pTimers->baseTimer.tickRemainder = 0;
         break;
     case EVMU_ADDRESS_SFR_P3DDR:
         //if((pSelf_->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_EXT)]&EVMU_SFR_EXT_MASK) == EVMU_SFR_EXT_USER) {

--- a/lib/source/hw/evmu_timers.c
+++ b/lib/source/hw/evmu_timers.c
@@ -2,6 +2,127 @@
 #include "evmu_ram_.h"
 #include "evmu_device_.h"
 #include "evmu_buzzer_.h"
+#include <evmu/hw/evmu_clock.h>
+
+#define EVMU_BASE_TIMER_COUNTER_BITS_  14u
+#define EVMU_BASE_TIMER_COUNTER_MAX_   (1u << EVMU_BASE_TIMER_COUNTER_BITS_)
+#define EVMU_BASE_TIMER_COUNTER_MASK_  (EVMU_BASE_TIMER_COUNTER_MAX_ - 1u)
+
+typedef enum EVMU_BASE_TIMER_CLOCK_ {
+    EVMU_BASE_TIMER_CLOCK__QUARTZ_,
+    EVMU_BASE_TIMER_CLOCK__CYCLE_,
+    EVMU_BASE_TIMER_CLOCK__T0_PRESCALER_
+} EVMU_BASE_TIMER_CLOCK_;
+
+static EVMU_BASE_TIMER_CLOCK_ baseTimerClock_(const EvmuRam_* pRam) {
+    switch((pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_ISL)] >> 4u) & 0x3u) {
+    case 0x1u:
+        return EVMU_BASE_TIMER_CLOCK__CYCLE_;
+    case 0x3u:
+        return EVMU_BASE_TIMER_CLOCK__T0_PRESCALER_;
+    default:
+        return EVMU_BASE_TIMER_CLOCK__QUARTZ_;
+    }
+}
+
+static uint64_t oscillatorHz_(EVMU_OSCILLATOR oscillator) {
+    switch(oscillator) {
+    case EVMU_OSCILLATOR_CF:
+        return EVMU_CLOCK_OSC_CF_FREQ;
+    case EVMU_OSCILLATOR_QUARTZ:
+        return EVMU_CLOCK_OSC_QUARTZ_FREQ;
+    default:
+        return EVMU_CLOCK_OSC_RC_FREQ;
+    }
+}
+
+static unsigned dividerFactor_(EVMU_CLOCK_DIVIDER divider) {
+    switch(divider) {
+    case EVMU_CLOCK_DIVIDER_6:
+        return 6u;
+    case EVMU_CLOCK_DIVIDER_12:
+        return 12u;
+    default:
+        return 1u;
+    }
+}
+
+static unsigned consumeStartDelay_(unsigned* pDelay, unsigned ticks) {
+    const unsigned skipped = (*pDelay < ticks)? *pDelay : ticks;
+    *pDelay -= skipped;
+    return ticks - skipped;
+}
+
+static unsigned baseTimerInt0Rate_(EvmuWord btcr) {
+    return (btcr & EVMU_SFR_BTCR_INT0_CYCLE_CTRL_MASK)? 0x40u : 0x4000u;
+}
+
+static unsigned baseTimerInt1Rate_(EvmuWord btcr) {
+    switch(btcr & (EVMU_SFR_BTCR_INT0_CYCLE_CTRL_MASK |
+                   EVMU_SFR_BTCR_INT1_CYCLE_CTRL_MASK))
+    {
+    case 0x00u:
+    case 0x80u:
+        return 0x20u;
+    case 0x10u:
+    case 0x90u:
+        return 0x80u;
+    case 0x20u:
+        return 0x200u;
+    case 0x30u:
+        return 0x800u;
+    case 0xa0u:
+        return 0x2u;
+    case 0xb0u:
+        return 0x8u;
+    }
+
+    return 0u;
+}
+
+static unsigned baseTimerTicksElapsed_(EvmuTimers* pSelf,
+                                       EvmuDevice* pDevice,
+                                       unsigned    cpuCycles)
+{
+    EvmuTimers_* pSelf_ = EVMU_TIMERS_(pSelf);
+    EvmuRam_* pRam = pSelf_->pRam;
+
+    switch(baseTimerClock_(pRam)) {
+    case EVMU_BASE_TIMER_CLOCK__CYCLE_:
+        return consumeStartDelay_(&pSelf_->baseTimer.startDelayCycles, cpuCycles);
+    case EVMU_BASE_TIMER_CLOCK__T0_PRESCALER_:
+    {
+        pSelf_->baseTimer.startDelayCycles = 0;
+        const uint64_t scaledNumerator =
+            pSelf_->baseTimer.tickRemainder +
+            (uint64_t)cpuCycles;
+        const unsigned elapsed = (unsigned)(scaledNumerator / pSelf_->timer0.tscale);
+
+        pSelf_->baseTimer.tickRemainder = scaledNumerator % pSelf_->timer0.tscale;
+
+        return elapsed;
+    }
+    case EVMU_BASE_TIMER_CLOCK__QUARTZ_: {
+        pSelf_->baseTimer.startDelayCycles = 0;
+        EVMU_OSCILLATOR source = EVMU_OSCILLATOR_QUARTZ;
+        EVMU_CLOCK_DIVIDER divider = EVMU_CLOCK_DIVIDER_12;
+
+        EvmuClock_systemConfig(pDevice->pClock, &source, &divider);
+
+        const uint64_t systemHz = oscillatorHz_(source);
+        const uint64_t scaledNumerator =
+            pSelf_->baseTimer.tickRemainder +
+            (uint64_t)cpuCycles *
+            EVMU_CLOCK_OSC_QUARTZ_FREQ *
+            dividerFactor_(divider);
+        const unsigned elapsed = (unsigned)(scaledNumerator / systemHz);
+
+        pSelf_->baseTimer.tickRemainder = scaledNumerator % systemHz;
+
+        return elapsed;
+    }
+    }
+}
 
 static unsigned advanceReloadCounter(unsigned* pCounter,
                                       unsigned  ticks,
@@ -64,12 +185,6 @@ static unsigned advanceReloadCounter16(EvmuTimer* pTimer,
     return overflowCount;
 }
 
-static unsigned consumeStartDelay_(unsigned* pDelay, unsigned ticks) {
-    const unsigned skipped = (*pDelay < ticks)? *pDelay : ticks;
-    *pDelay -= skipped;
-    return ticks - skipped;
-}
-
 static unsigned advanceChainedReloadCounter16_(EvmuTimer* pTimer,
                                                 unsigned   ticks,
                                                 EvmuWord   reloadLow,
@@ -91,39 +206,32 @@ static void EvmuTimers_updateBaseTimer_(EvmuTimers* pSelf) {
     EvmuTimers_* pSelf_  = EVMU_TIMERS_(pSelf);
     EvmuRam_*    pRam    = pSelf_->pRam;
     EvmuDevice*  pDevice = EvmuPeripheral_device(EVMU_PERIPHERAL(pSelf));
-
     EvmuWord btcr = EvmuRam_readData(pDevice->pRam, EVMU_ADDRESS_SFR_BTCR);
+    const unsigned cpuCycles = (unsigned)EvmuCpu_cycles(pDevice->pCpu);
+    const unsigned elapsed = baseTimerTicksElapsed_(pSelf, pDevice, cpuCycles);
 
-    if(pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_BTCR)] & EVMU_SFR_BTCR_OP_CTRL_MASK) {
-#if 1
-        //hard-coded to generate interrupt every 0.5s by VMU
-        const double tCyc = EvmuCpu_secs(pDevice->pCpu);
+    if(!(btcr & EVMU_SFR_BTCR_OP_CTRL_MASK))
+        return;
 
-        pSelf_->baseTimer.tBaseDeltaTime += tCyc;
-        pSelf_->baseTimer.tBase1DeltaTime += tCyc;
-        if(pSelf_->baseTimer.tBase1DeltaTime >= 0.1f) { //call this many cycles 0.1s...
-            pSelf_->baseTimer.tBase1DeltaTime -= 0.1f;
+    if(elapsed) {
+        const unsigned currentCounter = pSelf_->baseTimer.counter;
+        const unsigned nextCounter = currentCounter + elapsed;
+        const unsigned int0Rate = baseTimerInt0Rate_(btcr);
+        const unsigned int1Rate = baseTimerInt1Rate_(btcr);
+
+        if(int1Rate && (currentCounter / int1Rate) < (nextCounter / int1Rate)) {
             pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_BTCR)] |= EVMU_SFR_BTCR_INT1_SRC_MASK;
-            if(pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_BTCR)] & EVMU_SFR_BTCR_INT1_REQ_EN_MASK)
+            if(btcr & EVMU_SFR_BTCR_INT1_REQ_EN_MASK)
                 EvmuPic_raiseIrq(pDevice->pPic, EVMU_IRQ_EXT_INT3_TBASE);
         }
 
-        if(pSelf_->baseTimer.tBaseDeltaTime >= 0.5f) { //call this many cycles 0.5s...
-            pSelf_->baseTimer.tBaseDeltaTime -= 0.5f;
+        if((currentCounter / int0Rate) < (nextCounter / int0Rate)) {
             pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_BTCR)] |= EVMU_SFR_BTCR_INT0_SRC_MASK;
-            if(pRam->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_BTCR)] & EVMU_SFR_BTCR_INT0_REQ_EN_MASK)
+            if(btcr & EVMU_SFR_BTCR_INT0_REQ_EN_MASK)
                 EvmuPic_raiseIrq(pDevice->pPic, EVMU_IRQ_EXT_INT3_TBASE);
         }
-#else
-     const EvmuCycles cycles =  EvmuCpu_cycles(pDevice->pCpu);
 
-     if(btcr & EVMU_SFR_BTCR_INT0_CYCLE_CTRL_MASK)
-         pSelf_->baseTimer.th += cycles;
-     else if(pSelf_->baseTimer.tl & 0x100)
-         pSelf_->baseTimer.th += cycles;
-
-
-#endif
+        pSelf_->baseTimer.counter = (uint16_t)(nextCounter & EVMU_BASE_TIMER_COUNTER_MASK_);
     }
 }
 

--- a/lib/source/hw/evmu_timers_.h
+++ b/lib/source/hw/evmu_timers_.h
@@ -29,10 +29,9 @@ GBL_DECLARE_STRUCT(EvmuTimer1) {
 };
 
 GBL_DECLARE_STRUCT(EvmuBaseTimer) {
-    float tBaseDeltaTime;
-    float tBase1DeltaTime;
-    uint8_t tl;
-    uint8_t th;
+    uint16_t counter;
+    uint64_t tickRemainder;
+    unsigned startDelayCycles;
 };
 
 GBL_DECLARE_STRUCT(EvmuTimers_) {

--- a/test/source/evmu_cpu_test_suite.c
+++ b/test/source/evmu_cpu_test_suite.c
@@ -1,11 +1,25 @@
 #include "evmu_cpu_test_suite.h"
+#include <gimbal/algorithms/gimbal_hash.h>
+#include <gimbal/containers/gimbal_ring_list.h>
 #include <gimbal/test/gimbal_test_macros.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <evmu/hw/evmu_device.h>
 #include <evmu/hw/evmu_isa.h>
 #include <evmu/hw/evmu_sfr.h>
 #include <evmu/hw/evmu_address_space.h>
 #include <evmu/hw/evmu_pic.h>
 #include <evmu/hw/evmu_flash.h>
+#include <evmu/hw/evmu_buzzer.h>
+#include <evmu/hw/evmu_wave.h>
+#include <evmu/fs/evmu_fs_utils.h>
+#include <evmu/fs/evmu_vmi.h>
+#include <evmu/fs/evmu_vms.h>
+#include "../../legacy/include/evmu-core/gyro_vmu_flash.h"
+#include "../../lib/source/hw/evmu_cpu_.h"
+#include "../../lib/source/hw/evmu_device_.h"
+#include "../../lib/source/hw/evmu_pic_.h"
+#include "../../lib/source/hw/evmu_timers_.h"
 
 #define EVMU_CPU_TEST_SUITE_(instance)  (GBL_PRIVATE(EvmuCpuTestSuite, instance))
 
@@ -32,6 +46,30 @@ GBL_TEST_FINAL() {
     GBL_UNREF(pFixture->pDevice);
     GBL_TEST_CASE_END;
 }
+
+static GBL_RESULT byteArrayUnref_(void* pValue, void* pClosure) {
+    (void)pClosure;
+    GblByteArray_unref((GblByteArray*)pValue);
+    return GBL_RESULT_SUCCESS;
+}
+
+static void setNopInstruction_(EvmuCpu* pCpu) {
+    EvmuCpu_* pCpu_ = EVMU_CPU_(pCpu);
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_NOP;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_NOP);
+}
+
+static void stepBaseTimer_(EvmuDevice* pDevice, unsigned steps) {
+    setNopInstruction_(pDevice->pCpu);
+
+    for(unsigned i = 0; i < steps; ++i)
+        EvmuTimers_update(pDevice->pTimers);
+}
+
+static void baseTimerDefaultHalfSecondQuartz_(GblTestFixture* pFixture);
+static void baseTimerCycleClockModes_(GblTestFixture* pFixture);
+static void baseTimerStopClearsCounter_(GblTestFixture* pFixture);
+static void baseTimerT0PrescalerSource_(GblTestFixture* pFixture);
 
 GBL_TEST_CASE(nop) {
     GBL_CTX_VERIFY_CALL(EvmuCpu_execute(pFixture->pDevice->pCpu,
@@ -1508,6 +1546,24 @@ GBL_TEST_CASE(div) {
     GBL_TEST_CALL(testPswFlags_(pSelf, GBL_FALSE, GBL_TRUE, GBL_FALSE));
 
     // Case 2
+    // Exact division clears OV when the divisor is non-zero.
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_PSW, 0xc0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_ACC, 0x0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_C,   0x10);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_B,   0x4);
+
+    GBL_TEST_CALL(EvmuCpu_execute(pFixture->pDevice->pCpu,
+                                  &(const EvmuDecodedInstruction) {
+                                      .opcode = EVMU_OPCODE_DIV
+                                  }));
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_ACC), 0x0);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_C),   0x4);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_B),   0x0);
+
+    GBL_TEST_CALL(testPswFlags_(pSelf, GBL_FALSE, GBL_TRUE, GBL_FALSE));
+
+    // Case 3
     EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_PSW, 0xc0);
     EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_ACC, 0x7);
     EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_C,   0x10);
@@ -2474,6 +2530,1041 @@ GBL_TEST_CASE(stf) {
     GBL_TEST_CASE_END;
 }
 
+GBL_TEST_CASE(timerStartDelay16) {
+    EvmuDevice_* pDevice_ = EVMU_DEVICE_(pFixture->pDevice);
+    EvmuCpu_*    pCpu_    = EVMU_CPU_(pFixture->pCpu);
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_MOV;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_MOV);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0PRR, 0xff);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0LR,  0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0HR,  0x00);
+    pDevice_->pTimers->timer0.base.tl = 0x00;
+    pDevice_->pTimers->timer0.base.th = 0x00;
+    EvmuRam_writeData(pFixture->pRam,
+                      EVMU_ADDRESS_SFR_T0CNT,
+                      EVMU_SFR_T0CNT_P0LONG_MASK |
+                      EVMU_SFR_T0CNT_P0LRUN_MASK |
+                      EVMU_SFR_T0CNT_P0HRUN_MASK);
+
+    EvmuTimers_update(pFixture->pDevice->pTimers);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T0L), 0x01);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T0H), 0x00);
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_NOP;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_NOP);
+
+    EvmuTimers_update(pFixture->pDevice->pTimers);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T0L), 0x02);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T0H), 0x00);
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_MOV;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_MOV);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LR,  0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1HR,  0x00);
+    pDevice_->pTimers->timer1.base.tl = 0x00;
+    pDevice_->pTimers->timer1.base.th = 0x00;
+    EvmuRam_writeData(pFixture->pRam,
+                      EVMU_ADDRESS_SFR_T1CNT,
+                      EVMU_SFR_T1CNT_T1LONG_MASK |
+                      EVMU_SFR_T1CNT_T1LRUN_MASK |
+                      EVMU_SFR_T1CNT_T1HRUN_MASK);
+
+    EvmuTimers_update(pFixture->pDevice->pTimers);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1L), 0x01);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1H), 0x00);
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_NOP;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_NOP);
+
+    EvmuTimers_update(pFixture->pDevice->pTimers);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1L), 0x02);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1H), 0x00);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(timerCounterWriteStopped) {
+    EvmuDevice_* pDevice_ = EVMU_DEVICE_(pFixture->pDevice);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0CNT, 0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT, 0x00);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0L, 0x12);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0H, 0x34);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1L, 0x56);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1H, 0x78);
+
+    GBL_TEST_COMPARE(pDevice_->pTimers->timer0.base.tl, 0x12);
+    GBL_TEST_COMPARE(pDevice_->pTimers->timer0.base.th, 0x34);
+    GBL_TEST_COMPARE(pDevice_->pTimers->timer1.base.tl, 0x56);
+    GBL_TEST_COMPARE(pDevice_->pTimers->timer1.base.th, 0x78);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T0L), 0x12);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T0H), 0x34);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1L), 0x56);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1H), 0x78);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(clockTicksPerCycle) {
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR) &
+                         (EVMU_SFR_OCR_OCR7_MASK |
+                          EVMU_SFR_OCR_OCR5_MASK |
+                          EVMU_SFR_OCR_OCR4_MASK |
+                          EVMU_SFR_OCR_OCR1_MASK |
+                          EVMU_SFR_OCR_OCR0_MASK),
+                     EVMU_SFR_OCR_OCR7_MASK |
+                     EVMU_SFR_OCR_OCR5_MASK |
+                     EVMU_SFR_OCR_OCR1_MASK |
+                     EVMU_SFR_OCR_OCR0_MASK);
+    GBL_TEST_COMPARE(EvmuClock_systemTicksPerCycle(pFixture->pDevice->pClock),
+                     EVMU_CLOCK_OSC_QUARTZ_TCYC_1_6);
+
+    const struct {
+        EvmuWord  ocr;
+        EvmuTicks ticks;
+    } cases[] = {
+        { 0x00,                                      EVMU_CLOCK_OSC_RC_TCYC_1_12     },
+        { EVMU_SFR_OCR_OCR7_MASK,                    EVMU_CLOCK_OSC_RC_TCYC_1_6      },
+        { EVMU_SFR_OCR_OCR5_MASK,                    EVMU_CLOCK_OSC_QUARTZ_TCYC_1_12 },
+        { EVMU_SFR_OCR_OCR5_MASK | EVMU_SFR_OCR_OCR7_MASK,
+                                                    EVMU_CLOCK_OSC_QUARTZ_TCYC_1_6  },
+        { EVMU_SFR_OCR_OCR4_MASK,                    EVMU_CLOCK_OSC_CF_TCYC_1_12     },
+        { EVMU_SFR_OCR_OCR4_MASK | EVMU_SFR_OCR_OCR7_MASK,
+                                                    EVMU_CLOCK_OSC_CF_TCYC_1_6      },
+        { EVMU_SFR_OCR_OCR5_MASK | EVMU_SFR_OCR_OCR4_MASK,
+                                                    EVMU_CLOCK_OSC_CF_TCYC_1_12     },
+        { EVMU_SFR_OCR_OCR5_MASK | EVMU_SFR_OCR_OCR4_MASK |
+          EVMU_SFR_OCR_OCR7_MASK,                    EVMU_CLOCK_OSC_CF_TCYC_1_6      }
+    };
+
+    for(size_t i = 0; i < sizeof(cases)/sizeof(cases[0]); ++i) {
+        const EvmuTicks ticks = cases[i].ticks;
+        EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR, cases[i].ocr);
+
+        GBL_TEST_COMPARE(EvmuClock_systemTicksPerCycle(pFixture->pDevice->pClock),
+                         ticks);
+        GBL_TEST_COMPARE((EvmuTicks)(EvmuClock_systemSecsPerCycle(pFixture->pDevice->pClock) *
+                                     1000000000.0 + 0.5),
+                         ticks);
+    }
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(clockOcrReadbackHighBits) {
+    const EvmuWord ocrControlBits =
+        EVMU_SFR_OCR_OCR7_MASK | EVMU_SFR_OCR_OCR0_MASK;
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR, ocrControlBits);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR),
+                     0xcd);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR) &
+                         (EVMU_SFR_OCR_OCR7_MASK |
+                          EVMU_SFR_OCR_OCR5_MASK |
+                          EVMU_SFR_OCR_OCR4_MASK |
+                          EVMU_SFR_OCR_OCR1_MASK |
+                          EVMU_SFR_OCR_OCR0_MASK),
+                     ocrControlBits);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(clockApiReflectsAndUpdatesRegisters) {
+    EvmuClock* pClock = pFixture->pDevice->pClock;
+    EVMU_OSCILLATOR source = EVMU_OSCILLATOR_CF;
+    EVMU_CLOCK_DIVIDER divider = EVMU_CLOCK_DIVIDER_1;
+    GBL_RESULT result = GBL_RESULT_SUCCESS;
+
+    GBL_TEST_VERIFY(EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_QUARTZ));
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setOscillatorActive(pClock, EVMU_OSCILLATOR_RC, GBL_FALSE)));
+    GBL_TEST_VERIFY(!EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_RC));
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setOscillatorActive(pClock, EVMU_OSCILLATOR_CF, GBL_FALSE)));
+    GBL_TEST_VERIFY(!EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_CF));
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR) &
+                         (EVMU_SFR_OCR_OCR1_MASK | EVMU_SFR_OCR_OCR0_MASK),
+                     EVMU_SFR_OCR_OCR1_MASK | EVMU_SFR_OCR_OCR0_MASK);
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setOscillatorActive(pClock, EVMU_OSCILLATOR_RC, GBL_TRUE)));
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setOscillatorActive(pClock, EVMU_OSCILLATOR_CF, GBL_TRUE)));
+    GBL_TEST_VERIFY(EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_RC));
+    GBL_TEST_VERIFY(EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_CF));
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR) &
+                         (EVMU_SFR_OCR_OCR1_MASK | EVMU_SFR_OCR_OCR0_MASK),
+                     0);
+
+    GBL_TEST_EXPECT_ERROR();
+    result = EvmuClock_setOscillatorActive(pClock, EVMU_OSCILLATOR_QUARTZ, GBL_FALSE);
+    GBL_TEST_VERIFY(!GBL_RESULT_SUCCESS(result));
+    GBL_TEST_COMPARE(GBL_CTX_LAST_RESULT(), GBL_RESULT_ERROR_INVALID_OPERATION);
+    GBL_CTX_CLEAR_LAST_RECORD();
+    GBL_TEST_VERIFY(EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_QUARTZ));
+
+    GBL_TEST_COMPARE(EvmuClock_systemState(pClock), EVMU_CLOCK_SYSTEM_STATE_RUNNING);
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setSystemState(pClock, EVMU_CLOCK_SYSTEM_STATE_HALT)));
+    GBL_TEST_COMPARE(EvmuClock_systemState(pClock), EVMU_CLOCK_SYSTEM_STATE_HALT);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_PCON),
+                     EVMU_SFR_PCON_HALT_MASK);
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setSystemState(pClock, EVMU_CLOCK_SYSTEM_STATE_HOLD)));
+    GBL_TEST_COMPARE(EvmuClock_systemState(pClock), EVMU_CLOCK_SYSTEM_STATE_HOLD);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_PCON),
+                     EVMU_SFR_PCON_HOLD_MASK);
+    GBL_TEST_VERIFY(!EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_QUARTZ));
+    GBL_TEST_VERIFY(!EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_RC));
+    GBL_TEST_VERIFY(!EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_CF));
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setSystemState(pClock, EVMU_CLOCK_SYSTEM_STATE_RUNNING)));
+    GBL_TEST_COMPARE(EvmuClock_systemState(pClock), EVMU_CLOCK_SYSTEM_STATE_RUNNING);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_PCON), 0);
+    GBL_TEST_VERIFY(EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_QUARTZ));
+    GBL_TEST_VERIFY(EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_RC));
+    GBL_TEST_VERIFY(EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_CF));
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setSystemConfig(pClock,
+                                                                 EVMU_OSCILLATOR_QUARTZ,
+                                                                 EVMU_CLOCK_DIVIDER_6)));
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_systemConfig(pClock, &source, &divider)));
+    GBL_TEST_COMPARE(source, EVMU_OSCILLATOR_QUARTZ);
+    GBL_TEST_COMPARE(divider, EVMU_CLOCK_DIVIDER_6);
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setSystemConfig(pClock,
+                                                                 EVMU_OSCILLATOR_CF,
+                                                                 EVMU_CLOCK_DIVIDER_12)));
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_systemConfig(pClock, &source, &divider)));
+    GBL_TEST_COMPARE(source, EVMU_OSCILLATOR_CF);
+    GBL_TEST_COMPARE(divider, EVMU_CLOCK_DIVIDER_12);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR) &
+                         (EVMU_SFR_OCR_OCR7_MASK | EVMU_SFR_OCR_OCR5_MASK | EVMU_SFR_OCR_OCR4_MASK),
+                     EVMU_SFR_OCR_OCR4_MASK);
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setSystemConfig(pClock,
+                                                                 EVMU_OSCILLATOR_RC,
+                                                                 EVMU_CLOCK_DIVIDER_6)));
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_systemConfig(pClock, &source, &divider)));
+    GBL_TEST_COMPARE(source, EVMU_OSCILLATOR_RC);
+    GBL_TEST_COMPARE(divider, EVMU_CLOCK_DIVIDER_6);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR) &
+                         (EVMU_SFR_OCR_OCR7_MASK | EVMU_SFR_OCR_OCR5_MASK | EVMU_SFR_OCR_OCR4_MASK),
+                     EVMU_SFR_OCR_OCR7_MASK);
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setSystemConfig(pClock,
+                                                                 EVMU_OSCILLATOR_QUARTZ,
+                                                                 EVMU_CLOCK_DIVIDER_12)));
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_systemConfig(pClock, &source, &divider)));
+    GBL_TEST_COMPARE(source, EVMU_OSCILLATOR_QUARTZ);
+    GBL_TEST_COMPARE(divider, EVMU_CLOCK_DIVIDER_12);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR) &
+                         (EVMU_SFR_OCR_OCR7_MASK | EVMU_SFR_OCR_OCR5_MASK | EVMU_SFR_OCR_OCR4_MASK),
+                     EVMU_SFR_OCR_OCR5_MASK);
+
+    GBL_TEST_EXPECT_ERROR();
+    result = EvmuClock_setSystemConfig(pClock,
+                                       EVMU_OSCILLATOR_CF,
+                                       EVMU_CLOCK_DIVIDER_1);
+    GBL_TEST_VERIFY(!GBL_RESULT_SUCCESS(result));
+    GBL_TEST_COMPARE(GBL_CTX_LAST_RESULT(), GBL_RESULT_ERROR_INVALID_ARG);
+    GBL_CTX_CLEAR_LAST_RECORD();
+
+    baseTimerDefaultHalfSecondQuartz_(pFixture);
+    baseTimerCycleClockModes_(pFixture);
+    baseTimerStopClearsCounter_(pFixture);
+    baseTimerT0PrescalerSource_(pFixture);
+
+    GBL_TEST_CASE_END;
+}
+
+static void baseTimerDefaultHalfSecondQuartz_(GblTestFixture* pFixture) {
+    GBL_CTX_BEGIN(NULL);
+
+    EvmuPic_* pPic_ = EVMU_PIC_(pFixture->pDevice->pPic);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    pPic_->intReq = 0;
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR,
+                      EVMU_SFR_OCR_OCR7_MASK |
+                      EVMU_SFR_OCR_OCR5_MASK |
+                      EVMU_SFR_OCR_OCR1_MASK |
+                      EVMU_SFR_OCR_OCR0_MASK);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_ISL, 0xc0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR,
+                      EVMU_SFR_BTCR_OP_CTRL_MASK |
+                      EVMU_SFR_BTCR_INT0_REQ_EN_MASK);
+
+    stepBaseTimer_(pFixture->pDevice, 2730);
+
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     16380);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT0_SRC_MASK,
+                     0);
+    GBL_TEST_COMPARE(pPic_->intReq & (1u << EVMU_IRQ_EXT_INT3_TBASE), 0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     2);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT0_SRC_MASK,
+                     EVMU_SFR_BTCR_INT0_SRC_MASK);
+    GBL_TEST_COMPARE(pPic_->intReq & (1u << EVMU_IRQ_EXT_INT3_TBASE),
+                     (EvmuIrqMask)(1u << EVMU_IRQ_EXT_INT3_TBASE));
+
+    GBL_CTX_END_BLOCK();
+}
+
+static void baseTimerCycleClockModes_(GblTestFixture* pFixture) {
+    GBL_CTX_BEGIN(NULL);
+
+    EvmuPic_* pPic_ = EVMU_PIC_(pFixture->pDevice->pPic);
+    const EvmuWord islCycleClock = 0xd0;
+    const EvmuWord btcrInt1Fast2 =
+        EVMU_SFR_BTCR_OP_CTRL_MASK |
+        EVMU_SFR_BTCR_INT1_REQ_EN_MASK |
+        EVMU_SFR_BTCR_INT0_CYCLE_CTRL_MASK |
+        0x20u;
+    const EvmuWord btcrInt1Fast8 =
+        EVMU_SFR_BTCR_OP_CTRL_MASK |
+        EVMU_SFR_BTCR_INT1_REQ_EN_MASK |
+        EVMU_SFR_BTCR_INT0_CYCLE_CTRL_MASK |
+        0x30u;
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    pPic_->intReq = 0;
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_ISL, islCycleClock);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR,
+                      EVMU_SFR_BTCR_OP_CTRL_MASK |
+                      EVMU_SFR_BTCR_INT1_REQ_EN_MASK);
+
+    stepBaseTimer_(pFixture->pDevice, 31);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     30);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     31);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     32);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     EVMU_SFR_BTCR_INT1_SRC_MASK);
+    GBL_TEST_COMPARE(pPic_->intReq & (1u << EVMU_IRQ_EXT_INT3_TBASE),
+                     (EvmuIrqMask)(1u << EVMU_IRQ_EXT_INT3_TBASE));
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    pPic_->intReq = 0;
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR,
+                      EVMU_SFR_BTCR_OP_CTRL_MASK |
+                      EVMU_SFR_BTCR_INT1_REQ_EN_MASK |
+                      EVMU_SFR_BTCR_INT1_CYCLE_CTRL_MASK);
+
+    stepBaseTimer_(pFixture->pDevice, 127);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     128);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     EVMU_SFR_BTCR_INT1_SRC_MASK);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR,
+                      EVMU_SFR_BTCR_OP_CTRL_MASK |
+                      EVMU_SFR_BTCR_INT0_REQ_EN_MASK |
+                      EVMU_SFR_BTCR_INT0_CYCLE_CTRL_MASK);
+    pPic_->intReq = 0;
+
+    stepBaseTimer_(pFixture->pDevice, 63);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT0_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT0_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     64);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT0_SRC_MASK,
+                     EVMU_SFR_BTCR_INT0_SRC_MASK);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, btcrInt1Fast2);
+    pPic_->intReq = 0;
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     2);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     EVMU_SFR_BTCR_INT1_SRC_MASK);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, btcrInt1Fast8);
+    pPic_->intReq = 0;
+
+    stepBaseTimer_(pFixture->pDevice, 7);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     8);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     EVMU_SFR_BTCR_INT1_SRC_MASK);
+
+    GBL_CTX_END_BLOCK();
+}
+
+static void baseTimerStopClearsCounter_(GblTestFixture* pFixture) {
+    GBL_CTX_BEGIN(NULL);
+
+    const EvmuWord islCycleClock = 0xd0;
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_ISL, islCycleClock);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR,
+                      EVMU_SFR_BTCR_OP_CTRL_MASK |
+                      EVMU_SFR_BTCR_INT1_REQ_EN_MASK);
+
+    stepBaseTimer_(pFixture->pDevice, 20);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     20);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 40);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     0);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         (EVMU_SFR_BTCR_INT0_SRC_MASK | EVMU_SFR_BTCR_INT1_SRC_MASK),
+                     0);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR,
+                      EVMU_SFR_BTCR_OP_CTRL_MASK |
+                      EVMU_SFR_BTCR_INT1_REQ_EN_MASK);
+    stepBaseTimer_(pFixture->pDevice, 33);
+
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     32);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     EVMU_SFR_BTCR_INT1_SRC_MASK);
+
+    GBL_CTX_END_BLOCK();
+}
+
+static void baseTimerT0PrescalerSource_(GblTestFixture* pFixture) {
+    GBL_CTX_BEGIN(NULL);
+
+    const EvmuWord islT0Prescaler = 0xf0;
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0PRR, 0xfd);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_ISL, islT0Prescaler);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR,
+                      EVMU_SFR_BTCR_OP_CTRL_MASK |
+                      EVMU_SFR_BTCR_INT1_REQ_EN_MASK);
+
+    stepBaseTimer_(pFixture->pDevice, 95);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     31);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     32);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     EVMU_SFR_BTCR_INT1_SRC_MASK);
+
+    GBL_CTX_END_BLOCK();
+}
+
+GBL_TEST_CASE(clockHoldStopsCpuAndTimers) {
+    EvmuDevice_* pDevice_ = EVMU_DEVICE_(pFixture->pDevice);
+    EvmuLcd* pLcd = pFixture->pDevice->pLcd;
+    const EvmuPc startPc = EvmuCpu_pc(pFixture->pDevice->pCpu);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0PRR, 0xff);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0LR, 0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0HR, 0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0CNT,
+                      EVMU_SFR_T0CNT_P0LRUN_MASK |
+                      EVMU_SFR_T0CNT_P0HRUN_MASK);
+
+    pDevice_->pTimers->timer0.base.tl = 0x12;
+    pDevice_->pTimers->timer0.base.th = 0x34;
+
+    EvmuLcd_setPixel(pLcd, 0, 0, GBL_TRUE);
+    EvmuLcd_setPixel(pLcd, 1, 0, GBL_FALSE);
+    EvmuIBehavior_update(EVMU_IBEHAVIOR(pLcd),
+                         EvmuLcd_refreshRateTicks(pLcd) * EVMU_LCD_SCREEN_REFRESH_DIVISOR);
+    GBL_TEST_VERIFY(EvmuLcd_decoratedPixel(pLcd, 0, 0) !=
+                    EvmuLcd_decoratedPixel(pLcd, 1, 0));
+
+    pLcd->screenChanged = GBL_FALSE;
+    EvmuClock_setSystemState(pFixture->pDevice->pClock,
+                             EVMU_CLOCK_SYSTEM_STATE_HOLD);
+    EvmuIBehavior_update(EVMU_IBEHAVIOR(pFixture->pDevice->pCpu),
+                         EVMU_CLOCK_OSC_QUARTZ_TCYC_1_6 * 16);
+
+    GBL_TEST_COMPARE(pLcd->screenChanged, GBL_TRUE);
+    GBL_TEST_COMPARE(EvmuCpu_pc(pFixture->pDevice->pCpu), startPc);
+    GBL_TEST_COMPARE(pDevice_->pTimers->timer0.base.tl, 0x12);
+    GBL_TEST_COMPARE(pDevice_->pTimers->timer0.base.th, 0x34);
+    GBL_TEST_COMPARE(EvmuLcd_pixel(pLcd, 0, 0), GBL_TRUE);
+    GBL_TEST_COMPARE(EvmuLcd_pixel(pLcd, 1, 0), GBL_FALSE);
+    GBL_TEST_COMPARE(EvmuLcd_decoratedPixel(pLcd, 0, 0), 255);
+    GBL_TEST_COMPARE(EvmuLcd_decoratedPixel(pLcd, 1, 0), 255);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_PCON),
+                     EVMU_SFR_PCON_HOLD_MASK);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(clockHoldCancelsOnPort3Input) {
+    EvmuGamepad* pGamepad = pFixture->pDevice->pGamepad;
+
+    EvmuClock_setSystemState(pFixture->pDevice->pClock,
+                             EVMU_CLOCK_SYSTEM_STATE_HOLD);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_P3INT,
+                      EVMU_SFR_P3INT_P32INT_MASK);
+    pFixture->pDevice->pLcd->screenChanged = GBL_FALSE;
+
+    pGamepad->a = GBL_TRUE;
+    EvmuIBehavior_update(EVMU_IBEHAVIOR(pGamepad), 0);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_PCON),
+                     0);
+    GBL_TEST_COMPARE(pFixture->pDevice->pLcd->screenChanged, GBL_TRUE);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_P3INT) &
+                         EVMU_SFR_P3INT_P31INT_MASK,
+                     EVMU_SFR_P3INT_P31INT_MASK);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(waveTransitions) {
+    EvmuWave wave = EVMU_WAVE_0_0;
+
+    EvmuWave_reset(&wave);
+    GBL_TEST_COMPARE(wave, EVMU_WAVE_X_X);
+    GBL_TEST_COMPARE(EvmuWave_logicPrevious(&wave), EVMU_LOGIC_X);
+    GBL_TEST_COMPARE(EvmuWave_logicCurrent(&wave), EVMU_LOGIC_X);
+    GBL_TEST_VERIFY(EvmuWave_hasStayedUnknown(&wave));
+
+    EvmuWave_update(&wave, EVMU_LOGIC_0);
+    GBL_TEST_COMPARE(wave, EVMU_WAVE_X_0);
+    GBL_TEST_COMPARE(EvmuWave_logicPrevious(&wave), EVMU_LOGIC_X);
+    GBL_TEST_COMPARE(EvmuWave_logicCurrent(&wave), EVMU_LOGIC_0);
+    GBL_TEST_VERIFY(EvmuWave_wasLogicUnknown(&wave));
+    GBL_TEST_VERIFY(EvmuWave_isLogicLow(&wave));
+    GBL_TEST_VERIFY(EvmuWave_hasChangedKnown(&wave));
+    GBL_TEST_VERIFY(EvmuWave_hasChangedValid(&wave));
+
+    EvmuWave_update(&wave, EVMU_LOGIC_1);
+    GBL_TEST_COMPARE(wave, EVMU_WAVE_0_1);
+    GBL_TEST_VERIFY(EvmuWave_hasChanged(&wave));
+    GBL_TEST_VERIFY(EvmuWave_hasChangedEdge(&wave));
+    GBL_TEST_VERIFY(EvmuWave_hasChangedEdgeRising(&wave));
+    GBL_TEST_VERIFY(EvmuWave_wasLogicLow(&wave));
+    GBL_TEST_VERIFY(EvmuWave_isLogicHigh(&wave));
+
+    EvmuWave_update(&wave, EVMU_LOGIC_1);
+    GBL_TEST_COMPARE(wave, EVMU_WAVE_1_1);
+    GBL_TEST_VERIFY(EvmuWave_hasStayed(&wave));
+    GBL_TEST_VERIFY(EvmuWave_hasStayedHigh(&wave));
+    GBL_TEST_VERIFY(!EvmuWave_hasChanged(&wave));
+
+    EvmuWave_update(&wave, EVMU_LOGIC_0);
+    GBL_TEST_COMPARE(wave, EVMU_WAVE_1_0);
+    GBL_TEST_VERIFY(EvmuWave_hasChangedEdge(&wave));
+    GBL_TEST_VERIFY(EvmuWave_hasChangedEdgeFalling(&wave));
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(fileReadWithoutHeaderSpansBlocks) {
+    enum {
+        kIconCount    = 3,
+        kPayloadBytes = 96
+    };
+
+    EvmuNewFileInfo info;
+    unsigned char fileData[EVMU_FAT_BLOCK_SIZE * 4] = {0};
+    unsigned char payload[kPayloadBytes];
+    unsigned char readData[kPayloadBytes];
+    EvmuVms* pVms = (EvmuVms*)fileData;
+
+    const size_t headerBytes = sizeof(EvmuVms) + kIconCount * EVMU_VMS_ICON_BITMAP_SIZE;
+    EvmuDirEntry* pEntry = NULL;
+
+    GBL_TEST_VERIFY(headerBytes > EVMU_FAT_BLOCK_SIZE);
+
+    pVms->iconCount = kIconCount;
+    pVms->animSpeed = 1;
+    pVms->eyecatchType = EVMU_VMS_EYECATCH_NONE;
+    pVms->crc = 1;
+    pVms->dataBytes = kPayloadBytes;
+
+    memset(fileData + sizeof(EvmuVms), 0xa5, headerBytes - sizeof(EvmuVms));
+
+    for(size_t i = 0; i < kPayloadBytes; ++i) {
+        payload[i] = (unsigned char)(0x40 + i);
+        fileData[headerBytes + i] = payload[i];
+    }
+
+    EvmuNewFileInfo_init(&info,
+                         "HDRSPAN",
+                         headerBytes + kPayloadBytes,
+                         EVMU_FILE_TYPE_DATA,
+                         EVMU_COPY_ALLOWED);
+
+    pEntry = EvmuFileManager_alloc(pFixture->pDevice->pFileMgr, &info, fileData);
+    GBL_TEST_VERIFY(pEntry);
+    GBL_TEST_VERIFY(pEntry->firstBlock != 0);
+    GBL_TEST_COMPARE(EvmuFileManager_visibleBytes(pFixture->pDevice->pFileMgr,
+                                                  pEntry,
+                                                  GBL_TRUE),
+                     pEntry->fileSize * EVMU_FAT_BLOCK_SIZE);
+    GBL_TEST_COMPARE(EvmuFileManager_visibleBytes(pFixture->pDevice->pFileMgr,
+                                                  pEntry,
+                                                  GBL_FALSE),
+                     pEntry->fileSize * EVMU_FAT_BLOCK_SIZE - headerBytes);
+
+    memset(readData, 0, sizeof(readData));
+    GBL_TEST_COMPARE(EvmuFileManager_read(pFixture->pDevice->pFileMgr,
+                                          pEntry,
+                                          readData,
+                                          sizeof(readData),
+                                          0,
+                                          GBL_FALSE),
+                     sizeof(readData));
+    GBL_TEST_COMPARE(memcmp(readData, payload, sizeof(payload)), 0);
+
+    memset(readData, 0, sizeof(readData));
+    GBL_TEST_COMPARE(EvmuFileManager_read(pFixture->pDevice->pFileMgr,
+                                          pEntry,
+                                          readData,
+                                          16,
+                                          7,
+                                          GBL_FALSE),
+                     16);
+    GBL_TEST_COMPARE(memcmp(readData, payload + 7, 16), 0);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(dciExportRoundTripsDataFile) {
+    unsigned char fileData[EVMU_FAT_BLOCK_SIZE] = {0};
+    unsigned char importedData[EVMU_FAT_BLOCK_SIZE] = {0};
+    EvmuNewFileInfo info;
+    EvmuDirEntry* pEntry = NULL;
+    EvmuDevice* pImportedDevice = NULL;
+    EvmuDirEntry* pImportedEntry = NULL;
+    VMU_LOAD_IMAGE_STATUS status = VMU_LOAD_IMAGE_SUCCESS;
+    struct stat fileStat = {0};
+    char pathTemplate[] = "/tmp/libevmu_dci_export_XXXXXX";
+    int fd = -1;
+    const size_t dataSize = sizeof(EvmuDirEntry) + sizeof(fileData);
+    const size_t bytesToWrite = dataSize + (dataSize % 4? 4 - dataSize % 4 : 0);
+
+    for(size_t i = 0; i < sizeof(fileData); ++i)
+        fileData[i] = (unsigned char)(0x30 + i);
+
+    EvmuNewFileInfo_init(&info,
+                         "DCIEXP",
+                         sizeof(fileData),
+                         EVMU_FILE_TYPE_DATA,
+                         EVMU_COPY_ALLOWED);
+
+    pEntry = EvmuFileManager_alloc(pFixture->pDevice->pFileMgr, &info, fileData);
+    GBL_TEST_VERIFY(pEntry);
+
+    fd = mkstemp(pathTemplate);
+    GBL_TEST_VERIFY(fd >= 0);
+    if(fd >= 0)
+        close(fd);
+    unlink(pathTemplate);
+
+    GBL_TEST_VERIFY(gyVmuFlashExportDci(pFixture->pDevice, pEntry, pathTemplate));
+    GBL_TEST_VERIFY(stat(pathTemplate, &fileStat) == 0);
+    GBL_TEST_COMPARE((size_t)fileStat.st_size, bytesToWrite);
+
+    pImportedDevice = GBL_OBJECT_NEW(EvmuDevice);
+    GBL_TEST_VERIFY(pImportedDevice);
+
+    pImportedEntry = gyVmuFlashLoadImageDci(pImportedDevice, pathTemplate, &status);
+    GBL_TEST_VERIFY(pImportedEntry);
+    GBL_TEST_COMPARE(status, VMU_LOAD_IMAGE_SUCCESS);
+    GBL_TEST_COMPARE(EvmuFileManager_read(pImportedDevice->pFileMgr,
+                                          pImportedEntry,
+                                          importedData,
+                                          sizeof(importedData),
+                                          0,
+                                          GBL_TRUE),
+                     sizeof(importedData));
+    GBL_TEST_COMPARE(memcmp(importedData, fileData, sizeof(fileData)), 0);
+
+    unlink(pathTemplate);
+    if(pImportedDevice)
+        GBL_UNREF(pImportedDevice);
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(vmsComputeCrcDoesNotMutate) {
+    enum { kDataBytes = 32 };
+
+    unsigned char fileBytes[sizeof(EvmuVms) + kDataBytes] = {0};
+    unsigned char original[sizeof(fileBytes)];
+    EvmuVms* pVms = (EvmuVms*)fileBytes;
+    EvmuVms headerCopy;
+    uint16_t expected = 0;
+
+    pVms->iconCount = 0;
+    pVms->animSpeed = 0;
+    pVms->eyecatchType = EVMU_VMS_EYECATCH_NONE;
+    pVms->crc = 0x1234;
+    pVms->dataBytes = kDataBytes;
+
+    for(size_t i = 0; i < kDataBytes; ++i)
+        fileBytes[sizeof(EvmuVms) + i] = (unsigned char)(0x40 + i);
+
+    memcpy(original, fileBytes, sizeof(fileBytes));
+
+    headerCopy = *pVms;
+    headerCopy.crc = 0;
+    expected = gblHashCrc16BitPartial(&headerCopy, sizeof(headerCopy), &expected);
+    expected = gblHashCrc16BitPartial(fileBytes + sizeof(EvmuVms), kDataBytes, &expected);
+
+    GBL_TEST_COMPARE(EvmuVms_computeCrc(pVms), expected);
+    GBL_TEST_COMPARE(memcmp(fileBytes, original, sizeof(fileBytes)), 0);
+    GBL_TEST_COMPARE(pVms->crc, 0x1234);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(vmsGuessFileTypeRejectsImpossibleDataSize) {
+    EvmuVms vms = {0};
+
+    vms.iconCount = 0;
+    vms.animSpeed = 0;
+    vms.eyecatchType = EVMU_VMS_EYECATCH_NONE;
+    vms.crc = 1;
+    vms.dataBytes =
+        EVMU_FAT_BLOCK_USERDATA_SIZE_DEFAULT * EVMU_FAT_BLOCK_SIZE + 1;
+
+    GBL_TEST_COMPARE(EvmuVms_guessFileType(&vms), EVMU_FILE_TYPE_NONE);
+
+    vms.dataBytes = 32;
+    GBL_TEST_COMPARE(EvmuVms_guessFileType(&vms), EVMU_FILE_TYPE_DATA);
+
+    vms.crc = 0;
+    GBL_TEST_COMPARE(EvmuVms_guessFileType(&vms), EVMU_FILE_TYPE_GAME);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(vmiFromVmsFileRejectsTruncatedInput) {
+    unsigned char shortBytes[64] = {0};
+    unsigned char oneBlock[EVMU_FAT_BLOCK_SIZE] = {0};
+    EvmuVms* pInvalidHeader = (EvmuVms*)oneBlock;
+    EvmuVmi vmi;
+
+    GBL_TEST_EXPECT_ERROR();
+    GBL_TEST_VERIFY(!GBL_RESULT_SUCCESS(EvmuVmi_fromVmsFile(&vmi,
+                                                            shortBytes,
+                                                            sizeof(shortBytes))));
+    GBL_TEST_COMPARE(GBL_CTX_LAST_RESULT(), EVMU_RESULT_ERROR_INVALID_FILE);
+    GBL_CTX_CLEAR_LAST_RECORD();
+
+    pInvalidHeader->eyecatchType = EVMU_VMS_EYECATCH_COUNT;
+
+    GBL_TEST_EXPECT_ERROR();
+    GBL_TEST_VERIFY(!GBL_RESULT_SUCCESS(EvmuVmi_fromVmsFile(&vmi,
+                                                            oneBlock,
+                                                            sizeof(oneBlock))));
+    GBL_TEST_COMPARE(GBL_CTX_LAST_RESULT(), EVMU_RESULT_ERROR_INVALID_FILE);
+    GBL_CTX_CLEAR_LAST_RECORD();
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(vmsCreateIconsArgb4444AllocatesDestSize) {
+    unsigned char fileBytes[sizeof(EvmuVms) + EVMU_VMS_ICON_BITMAP_SIZE] = {0};
+    EvmuVms* pVms = (EvmuVms*)fileBytes;
+    GblRingList* pIcons = NULL;
+    GblByteArray* pIcon = NULL;
+
+    pVms->iconCount = 1;
+    pVms->animSpeed = 0;
+    pVms->eyecatchType = EVMU_VMS_EYECATCH_NONE;
+    pVms->palette[0] = 0xffff;
+
+    pIcons = EvmuVms_createIconsArgb4444(pVms);
+    GBL_TEST_VERIFY(pIcons);
+    GBL_TEST_COMPARE(GblRingList_size(pIcons), 1);
+
+    pIcon = (GblByteArray*)GblRingList_front(pIcons);
+    GBL_TEST_VERIFY(pIcon);
+    GBL_TEST_COMPARE(pIcon->size,
+                     sizeof(uint16_t) *
+                     EVMU_VMS_ICON_BITMAP_WIDTH *
+                     EVMU_VMS_ICON_BITMAP_HEIGHT);
+
+    GblRingList_unref(pIcons, byteArrayUnref_, NULL);
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(vmsCreateIconsArgb4444WritesSequentialPixels) {
+    unsigned char fileBytes[sizeof(EvmuVms) + EVMU_VMS_ICON_BITMAP_SIZE] = {0};
+    EvmuVms* pVms = (EvmuVms*)fileBytes;
+    GblRingList* pIcons = NULL;
+    GblByteArray* pIcon = NULL;
+    uint16_t pixels[2] = {0};
+
+    pVms->iconCount = 1;
+    pVms->animSpeed = 0;
+    pVms->eyecatchType = EVMU_VMS_EYECATCH_NONE;
+    pVms->palette[1] = 0x1111;
+    pVms->palette[2] = 0x2222;
+
+    // First packed byte contains palette indices 1 then 2.
+    fileBytes[sizeof(EvmuVms)] = 0x12;
+
+    pIcons = EvmuVms_createIconsArgb4444(pVms);
+    GBL_TEST_VERIFY(pIcons);
+
+    pIcon = (GblByteArray*)GblRingList_front(pIcons);
+    GBL_TEST_VERIFY(pIcon);
+    GBL_CTX_VERIFY_CALL(GblByteArray_read(pIcon, 0, sizeof(pixels), pixels));
+
+    GBL_TEST_COMPARE(pixels[0], 0x1111);
+    GBL_TEST_COMPARE(pixels[1], 0x2222);
+
+    GblRingList_unref(pIcons, byteArrayUnref_, NULL);
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(lcdBlankWhenDisabled) {
+    EvmuLcd* pLcd = pFixture->pDevice->pLcd;
+
+    EvmuLcd_setPixel(pLcd, 0, 0, GBL_TRUE);
+    EvmuLcd_setPixel(pLcd, 1, 0, GBL_FALSE);
+
+    EvmuIBehavior_update(EVMU_IBEHAVIOR(pLcd),
+                         EvmuLcd_refreshRateTicks(pLcd) * EVMU_LCD_SCREEN_REFRESH_DIVISOR);
+
+    GBL_TEST_COMPARE(EvmuLcd_pixel(pLcd, 0, 0), GBL_TRUE);
+    GBL_TEST_COMPARE(EvmuLcd_pixel(pLcd, 1, 0), GBL_FALSE);
+    GBL_TEST_VERIFY(EvmuLcd_decoratedPixel(pLcd, 0, 0) !=
+                    EvmuLcd_decoratedPixel(pLcd, 1, 0));
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_VCCR, 0x00);
+
+    GBL_TEST_COMPARE(EvmuLcd_screenEnabled(pLcd), GBL_FALSE);
+    GBL_TEST_COMPARE(EvmuLcd_pixel(pLcd, 0, 0), GBL_TRUE);
+    GBL_TEST_COMPARE(EvmuLcd_pixel(pLcd, 1, 0), GBL_FALSE);
+    GBL_TEST_COMPARE(EvmuLcd_decoratedPixel(pLcd, 0, 0), 255);
+    GBL_TEST_COMPARE(EvmuLcd_decoratedPixel(pLcd, 1, 0), 255);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(buzzerMode1ComparatorLatchesPerCycle) {
+    EvmuCpu_* pCpu_ = EVMU_CPU_(pFixture->pCpu);
+    uint16_t period = 0;
+    uint8_t invPulseLength = 0;
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_NOP;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_NOP);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT, 0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_P1, 0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_P1DDR, EVMU_SFR_P1DDR_P17DDR_MASK);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_P1FCR, EVMU_SFR_P1FCR_P17FCR_MASK);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LR, 0xf0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LC, 0xf1);
+    EvmuRam_writeData(pFixture->pRam,
+                      EVMU_ADDRESS_SFR_T1CNT,
+                      EVMU_SFR_T1CNT_ELDT1C_MASK |
+                      EVMU_SFR_T1CNT_T1LRUN_MASK);
+
+    EvmuBuzzer_tone(pFixture->pDevice->pBuzzer, &period, &invPulseLength);
+    GBL_TEST_COMPARE(period, 16);
+    GBL_TEST_COMPARE(invPulseLength, 1);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LC, 0xf8);
+
+    EvmuBuzzer_tone(pFixture->pDevice->pBuzzer, &period, &invPulseLength);
+    GBL_TEST_COMPARE(period, 16);
+    GBL_TEST_COMPARE(invPulseLength, 1);
+
+    for(size_t i = 0; i < 32; ++i) {
+        if(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT) &
+           EVMU_SFR_T1CNT_T1LOVF_MASK)
+            break;
+
+        EvmuTimers_update(pFixture->pDevice->pTimers);
+    }
+
+    GBL_TEST_VERIFY(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT) &
+                    EVMU_SFR_T1CNT_T1LOVF_MASK);
+
+    EvmuBuzzer_tone(pFixture->pDevice->pBuzzer, &period, &invPulseLength);
+    GBL_TEST_COMPARE(period, 16);
+    GBL_TEST_COMPARE(invPulseLength, 8);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(buzzerMode1Eldt1cGatesComparatorUpdates) {
+    EvmuCpu_* pCpu_ = EVMU_CPU_(pFixture->pCpu);
+    uint16_t period = 0;
+    uint8_t invPulseLength = 0;
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_NOP;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_NOP);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT, 0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_P1, 0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_P1DDR, EVMU_SFR_P1DDR_P17DDR_MASK);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_P1FCR, EVMU_SFR_P1FCR_P17FCR_MASK);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LR, 0xf0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LC, 0xf1);
+    EvmuRam_writeData(pFixture->pRam,
+                      EVMU_ADDRESS_SFR_T1CNT,
+                      EVMU_SFR_T1CNT_T1LRUN_MASK);
+    EvmuBuzzer_tone(pFixture->pDevice->pBuzzer, &period, &invPulseLength);
+    GBL_TEST_COMPARE(period, 16);
+    GBL_TEST_COMPARE(invPulseLength, 1);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LC, 0xf8);
+
+    for(size_t i = 0; i < 32; ++i) {
+        if(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT) &
+           EVMU_SFR_T1CNT_T1LOVF_MASK)
+            break;
+
+        EvmuTimers_update(pFixture->pDevice->pTimers);
+    }
+
+    GBL_TEST_VERIFY(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT) &
+                    EVMU_SFR_T1CNT_T1LOVF_MASK);
+
+    EvmuBuzzer_tone(pFixture->pDevice->pBuzzer, &period, &invPulseLength);
+    GBL_TEST_COMPARE(period, 16);
+    GBL_TEST_COMPARE(invPulseLength, 1);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT, 0x00);
+    EvmuRam_writeData(pFixture->pRam,
+                      EVMU_ADDRESS_SFR_T1CNT,
+                      EVMU_SFR_T1CNT_T1LRUN_MASK);
+
+    EvmuBuzzer_tone(pFixture->pDevice->pBuzzer, &period, &invPulseLength);
+    GBL_TEST_COMPARE(period, 16);
+    GBL_TEST_COMPARE(invPulseLength, 8);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(timer1ReloadCascade16) {
+    EvmuDevice_* pDevice_ = EVMU_DEVICE_(pFixture->pDevice);
+    EvmuCpu_*    pCpu_    = EVMU_CPU_(pFixture->pCpu);
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_MOV;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_MOV);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LR,  0xfe);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1HR,  0xfe);
+    pDevice_->pTimers->timer1.base.tl = 0xfe;
+    pDevice_->pTimers->timer1.base.th = 0xfe;
+    EvmuRam_writeData(pFixture->pRam,
+                      EVMU_ADDRESS_SFR_T1CNT,
+                      EVMU_SFR_T1CNT_T1LONG_MASK |
+                      EVMU_SFR_T1CNT_T1LRUN_MASK |
+                      EVMU_SFR_T1CNT_T1HRUN_MASK);
+    EVMU_DEVICE_(pFixture->pDevice)->pTimers->timer1.startDelayCycles = 0;
+
+    EvmuTimers_update(pFixture->pDevice->pTimers);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1L), 0xfe);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1H), 0xff);
+    GBL_TEST_VERIFY(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT) &
+                    EVMU_SFR_T1CNT_T1LOVF_MASK);
+    GBL_TEST_VERIFY(!(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT) &
+                      EVMU_SFR_T1CNT_T1HOVF_MASK));
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_NOP;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_NOP);
+
+    EvmuTimers_update(pFixture->pDevice->pTimers);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1L), 0xff);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1H), 0xff);
+
+    EvmuTimers_update(pFixture->pDevice->pTimers);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1L), 0xfe);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1H), 0xfe);
+    GBL_TEST_VERIFY(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT) &
+                    EVMU_SFR_T1CNT_T1HOVF_MASK);
+
+    GBL_TEST_CASE_END;
+}
+
 GBL_TEST_REGISTER(nop,
                   ld,
                   ldInd,
@@ -2542,4 +3633,15 @@ GBL_TEST_REGISTER(nop,
                   ldc,
                   reti,
                   ldf,
-                  stf);
+                  stf,
+                  timerStartDelay16,
+                  timerCounterWriteStopped,
+                  clockTicksPerCycle,
+                  clockApiReflectsAndUpdatesRegisters,
+                  waveTransitions,
+                  fileReadWithoutHeaderSpansBlocks,
+                  dciExportRoundTripsDataFile,
+                  lcdBlankWhenDisabled,
+                  buzzerMode1ComparatorLatchesPerCycle,
+                  buzzerMode1Eldt1cGatesComparatorUpdates,
+                  timer1ReloadCascade16);

--- a/test/source/evmu_cpu_test_suite.c
+++ b/test/source/evmu_cpu_test_suite.c
@@ -1,11 +1,25 @@
 #include "evmu_cpu_test_suite.h"
+#include <gimbal/algorithms/gimbal_hash.h>
+#include <gimbal/containers/gimbal_ring_list.h>
 #include <gimbal/test/gimbal_test_macros.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <evmu/hw/evmu_device.h>
 #include <evmu/hw/evmu_isa.h>
 #include <evmu/hw/evmu_sfr.h>
 #include <evmu/hw/evmu_address_space.h>
 #include <evmu/hw/evmu_pic.h>
 #include <evmu/hw/evmu_flash.h>
+#include <evmu/hw/evmu_buzzer.h>
+#include <evmu/hw/evmu_wave.h>
+#include <evmu/fs/evmu_fs_utils.h>
+#include <evmu/fs/evmu_vmi.h>
+#include <evmu/fs/evmu_vms.h>
+#include "../../legacy/include/evmu-core/gyro_vmu_flash.h"
+#include "../../lib/source/hw/evmu_cpu_.h"
+#include "../../lib/source/hw/evmu_device_.h"
+#include "../../lib/source/hw/evmu_pic_.h"
+#include "../../lib/source/hw/evmu_timers_.h"
 
 #define EVMU_CPU_TEST_SUITE_(instance)  (GBL_PRIVATE(EvmuCpuTestSuite, instance))
 
@@ -32,6 +46,30 @@ GBL_TEST_FINAL() {
     GBL_UNREF(pFixture->pDevice);
     GBL_TEST_CASE_END;
 }
+
+static GBL_RESULT byteArrayUnref_(void* pValue, void* pClosure) {
+    (void)pClosure;
+    GblByteArray_unref((GblByteArray*)pValue);
+    return GBL_RESULT_SUCCESS;
+}
+
+static void setNopInstruction_(EvmuCpu* pCpu) {
+    EvmuCpu_* pCpu_ = EVMU_CPU_(pCpu);
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_NOP;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_NOP);
+}
+
+static void stepBaseTimer_(EvmuDevice* pDevice, unsigned steps) {
+    setNopInstruction_(pDevice->pCpu);
+
+    for(unsigned i = 0; i < steps; ++i)
+        EvmuTimers_update(pDevice->pTimers);
+}
+
+static void baseTimerDefaultHalfSecondQuartz_(GblTestFixture* pFixture);
+static void baseTimerCycleClockModes_(GblTestFixture* pFixture);
+static void baseTimerStopClearsCounter_(GblTestFixture* pFixture);
+static void baseTimerT0PrescalerSource_(GblTestFixture* pFixture);
 
 GBL_TEST_CASE(nop) {
     GBL_CTX_VERIFY_CALL(EvmuCpu_execute(pFixture->pDevice->pCpu,
@@ -1508,6 +1546,24 @@ GBL_TEST_CASE(div) {
     GBL_TEST_CALL(testPswFlags_(pSelf, GBL_FALSE, GBL_TRUE, GBL_FALSE));
 
     // Case 2
+    // Exact division clears OV when the divisor is non-zero.
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_PSW, 0xc0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_ACC, 0x0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_C,   0x10);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_B,   0x4);
+
+    GBL_TEST_CALL(EvmuCpu_execute(pFixture->pDevice->pCpu,
+                                  &(const EvmuDecodedInstruction) {
+                                      .opcode = EVMU_OPCODE_DIV
+                                  }));
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_ACC), 0x0);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_C),   0x4);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_B),   0x0);
+
+    GBL_TEST_CALL(testPswFlags_(pSelf, GBL_FALSE, GBL_TRUE, GBL_FALSE));
+
+    // Case 3
     EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_PSW, 0xc0);
     EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_ACC, 0x7);
     EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_C,   0x10);
@@ -2474,6 +2530,984 @@ GBL_TEST_CASE(stf) {
     GBL_TEST_CASE_END;
 }
 
+GBL_TEST_CASE(timerStartDelay16) {
+    EvmuDevice_* pDevice_ = EVMU_DEVICE_(pFixture->pDevice);
+    EvmuCpu_*    pCpu_    = EVMU_CPU_(pFixture->pCpu);
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_MOV;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_MOV);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0PRR, 0xff);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0LR,  0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0HR,  0x00);
+    pDevice_->pTimers->timer0.base.tl = 0x00;
+    pDevice_->pTimers->timer0.base.th = 0x00;
+    EvmuRam_writeData(pFixture->pRam,
+                      EVMU_ADDRESS_SFR_T0CNT,
+                      EVMU_SFR_T0CNT_P0LONG_MASK |
+                      EVMU_SFR_T0CNT_P0LRUN_MASK |
+                      EVMU_SFR_T0CNT_P0HRUN_MASK);
+
+    EvmuTimers_update(pFixture->pDevice->pTimers);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T0L), 0x01);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T0H), 0x00);
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_NOP;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_NOP);
+
+    EvmuTimers_update(pFixture->pDevice->pTimers);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T0L), 0x02);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T0H), 0x00);
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_MOV;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_MOV);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LR,  0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1HR,  0x00);
+    pDevice_->pTimers->timer1.base.tl = 0x00;
+    pDevice_->pTimers->timer1.base.th = 0x00;
+    EvmuRam_writeData(pFixture->pRam,
+                      EVMU_ADDRESS_SFR_T1CNT,
+                      EVMU_SFR_T1CNT_T1LONG_MASK |
+                      EVMU_SFR_T1CNT_T1LRUN_MASK |
+                      EVMU_SFR_T1CNT_T1HRUN_MASK);
+
+    EvmuTimers_update(pFixture->pDevice->pTimers);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1L), 0x01);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1H), 0x00);
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_NOP;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_NOP);
+
+    EvmuTimers_update(pFixture->pDevice->pTimers);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1L), 0x02);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1H), 0x00);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(timerCounterWriteStopped) {
+    EvmuDevice_* pDevice_ = EVMU_DEVICE_(pFixture->pDevice);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0CNT, 0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT, 0x00);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0L, 0x12);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0H, 0x34);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1L, 0x56);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1H, 0x78);
+
+    GBL_TEST_COMPARE(pDevice_->pTimers->timer0.base.tl, 0x12);
+    GBL_TEST_COMPARE(pDevice_->pTimers->timer0.base.th, 0x34);
+    GBL_TEST_COMPARE(pDevice_->pTimers->timer1.base.tl, 0x56);
+    GBL_TEST_COMPARE(pDevice_->pTimers->timer1.base.th, 0x78);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T0L), 0x12);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T0H), 0x34);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1L), 0x56);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1H), 0x78);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(clockTicksPerCycle) {
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR) &
+                         (EVMU_SFR_OCR_OCR7_MASK |
+                          EVMU_SFR_OCR_OCR5_MASK |
+                          EVMU_SFR_OCR_OCR4_MASK |
+                          EVMU_SFR_OCR_OCR1_MASK |
+                          EVMU_SFR_OCR_OCR0_MASK),
+                     EVMU_SFR_OCR_OCR7_MASK |
+                     EVMU_SFR_OCR_OCR5_MASK |
+                     EVMU_SFR_OCR_OCR1_MASK |
+                     EVMU_SFR_OCR_OCR0_MASK);
+    GBL_TEST_COMPARE(EvmuClock_systemTicksPerCycle(pFixture->pDevice->pClock),
+                     EVMU_CLOCK_OSC_QUARTZ_TCYC_1_6);
+
+    const struct {
+        EvmuWord  ocr;
+        EvmuTicks ticks;
+    } cases[] = {
+        { 0x00,                                      EVMU_CLOCK_OSC_RC_TCYC_1_12     },
+        { EVMU_SFR_OCR_OCR7_MASK,                    EVMU_CLOCK_OSC_RC_TCYC_1_6      },
+        { EVMU_SFR_OCR_OCR5_MASK,                    EVMU_CLOCK_OSC_QUARTZ_TCYC_1_12 },
+        { EVMU_SFR_OCR_OCR5_MASK | EVMU_SFR_OCR_OCR7_MASK,
+                                                    EVMU_CLOCK_OSC_QUARTZ_TCYC_1_6  },
+        { EVMU_SFR_OCR_OCR4_MASK,                    EVMU_CLOCK_OSC_CF_TCYC_1_12     },
+        { EVMU_SFR_OCR_OCR4_MASK | EVMU_SFR_OCR_OCR7_MASK,
+                                                    EVMU_CLOCK_OSC_CF_TCYC_1_6      },
+        { EVMU_SFR_OCR_OCR5_MASK | EVMU_SFR_OCR_OCR4_MASK,
+                                                    EVMU_CLOCK_OSC_CF_TCYC_1_12     },
+        { EVMU_SFR_OCR_OCR5_MASK | EVMU_SFR_OCR_OCR4_MASK |
+          EVMU_SFR_OCR_OCR7_MASK,                    EVMU_CLOCK_OSC_CF_TCYC_1_6      }
+    };
+
+    for(size_t i = 0; i < sizeof(cases)/sizeof(cases[0]); ++i) {
+        const EvmuTicks ticks = cases[i].ticks;
+        EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR, cases[i].ocr);
+
+        GBL_TEST_COMPARE(EvmuClock_systemTicksPerCycle(pFixture->pDevice->pClock),
+                         ticks);
+        GBL_TEST_COMPARE((EvmuTicks)(EvmuClock_systemSecsPerCycle(pFixture->pDevice->pClock) *
+                                     1000000000.0 + 0.5),
+                         ticks);
+    }
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(clockOcrReadbackHighBits) {
+    const EvmuWord ocrControlBits =
+        EVMU_SFR_OCR_OCR7_MASK | EVMU_SFR_OCR_OCR0_MASK;
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR, ocrControlBits);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR),
+                     0xcd);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR) &
+                         (EVMU_SFR_OCR_OCR7_MASK |
+                          EVMU_SFR_OCR_OCR5_MASK |
+                          EVMU_SFR_OCR_OCR4_MASK |
+                          EVMU_SFR_OCR_OCR1_MASK |
+                          EVMU_SFR_OCR_OCR0_MASK),
+                     ocrControlBits);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(clockApiReflectsAndUpdatesRegisters) {
+    EvmuClock* pClock = pFixture->pDevice->pClock;
+    EVMU_OSCILLATOR source = EVMU_OSCILLATOR_CF;
+    EVMU_CLOCK_DIVIDER divider = EVMU_CLOCK_DIVIDER_1;
+    GBL_RESULT result = GBL_RESULT_SUCCESS;
+
+    GBL_TEST_VERIFY(EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_QUARTZ));
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setOscillatorActive(pClock, EVMU_OSCILLATOR_RC, GBL_FALSE)));
+    GBL_TEST_VERIFY(!EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_RC));
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setOscillatorActive(pClock, EVMU_OSCILLATOR_CF, GBL_FALSE)));
+    GBL_TEST_VERIFY(!EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_CF));
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR) &
+                         (EVMU_SFR_OCR_OCR1_MASK | EVMU_SFR_OCR_OCR0_MASK),
+                     EVMU_SFR_OCR_OCR1_MASK | EVMU_SFR_OCR_OCR0_MASK);
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setOscillatorActive(pClock, EVMU_OSCILLATOR_RC, GBL_TRUE)));
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setOscillatorActive(pClock, EVMU_OSCILLATOR_CF, GBL_TRUE)));
+    GBL_TEST_VERIFY(EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_RC));
+    GBL_TEST_VERIFY(EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_CF));
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR) &
+                         (EVMU_SFR_OCR_OCR1_MASK | EVMU_SFR_OCR_OCR0_MASK),
+                     0);
+
+    GBL_TEST_EXPECT_ERROR();
+    result = EvmuClock_setOscillatorActive(pClock, EVMU_OSCILLATOR_QUARTZ, GBL_FALSE);
+    GBL_TEST_VERIFY(!GBL_RESULT_SUCCESS(result));
+    GBL_TEST_COMPARE(GBL_CTX_LAST_RESULT(), GBL_RESULT_ERROR_INVALID_OPERATION);
+    GBL_CTX_CLEAR_LAST_RECORD();
+    GBL_TEST_VERIFY(EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_QUARTZ));
+
+    GBL_TEST_COMPARE(EvmuClock_systemState(pClock), EVMU_CLOCK_SYSTEM_STATE_RUNNING);
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setSystemState(pClock, EVMU_CLOCK_SYSTEM_STATE_HALT)));
+    GBL_TEST_COMPARE(EvmuClock_systemState(pClock), EVMU_CLOCK_SYSTEM_STATE_HALT);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_PCON),
+                     EVMU_SFR_PCON_HALT_MASK);
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setSystemState(pClock, EVMU_CLOCK_SYSTEM_STATE_HOLD)));
+    GBL_TEST_COMPARE(EvmuClock_systemState(pClock), EVMU_CLOCK_SYSTEM_STATE_HOLD);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_PCON),
+                     EVMU_SFR_PCON_HOLD_MASK);
+    GBL_TEST_VERIFY(!EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_QUARTZ));
+    GBL_TEST_VERIFY(!EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_RC));
+    GBL_TEST_VERIFY(!EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_CF));
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setSystemState(pClock, EVMU_CLOCK_SYSTEM_STATE_RUNNING)));
+    GBL_TEST_COMPARE(EvmuClock_systemState(pClock), EVMU_CLOCK_SYSTEM_STATE_RUNNING);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_PCON), 0);
+    GBL_TEST_VERIFY(EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_QUARTZ));
+    GBL_TEST_VERIFY(EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_RC));
+    GBL_TEST_VERIFY(EvmuClock_oscillatorActive(pClock, EVMU_OSCILLATOR_CF));
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setSystemConfig(pClock,
+                                                                 EVMU_OSCILLATOR_QUARTZ,
+                                                                 EVMU_CLOCK_DIVIDER_6)));
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_systemConfig(pClock, &source, &divider)));
+    GBL_TEST_COMPARE(source, EVMU_OSCILLATOR_QUARTZ);
+    GBL_TEST_COMPARE(divider, EVMU_CLOCK_DIVIDER_6);
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setSystemConfig(pClock,
+                                                                 EVMU_OSCILLATOR_CF,
+                                                                 EVMU_CLOCK_DIVIDER_12)));
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_systemConfig(pClock, &source, &divider)));
+    GBL_TEST_COMPARE(source, EVMU_OSCILLATOR_CF);
+    GBL_TEST_COMPARE(divider, EVMU_CLOCK_DIVIDER_12);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR) &
+                         (EVMU_SFR_OCR_OCR7_MASK | EVMU_SFR_OCR_OCR5_MASK | EVMU_SFR_OCR_OCR4_MASK),
+                     EVMU_SFR_OCR_OCR4_MASK);
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setSystemConfig(pClock,
+                                                                 EVMU_OSCILLATOR_RC,
+                                                                 EVMU_CLOCK_DIVIDER_6)));
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_systemConfig(pClock, &source, &divider)));
+    GBL_TEST_COMPARE(source, EVMU_OSCILLATOR_RC);
+    GBL_TEST_COMPARE(divider, EVMU_CLOCK_DIVIDER_6);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR) &
+                         (EVMU_SFR_OCR_OCR7_MASK | EVMU_SFR_OCR_OCR5_MASK | EVMU_SFR_OCR_OCR4_MASK),
+                     EVMU_SFR_OCR_OCR7_MASK);
+
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_setSystemConfig(pClock,
+                                                                 EVMU_OSCILLATOR_QUARTZ,
+                                                                 EVMU_CLOCK_DIVIDER_12)));
+    GBL_TEST_VERIFY(GBL_RESULT_SUCCESS(EvmuClock_systemConfig(pClock, &source, &divider)));
+    GBL_TEST_COMPARE(source, EVMU_OSCILLATOR_QUARTZ);
+    GBL_TEST_COMPARE(divider, EVMU_CLOCK_DIVIDER_12);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR) &
+                         (EVMU_SFR_OCR_OCR7_MASK | EVMU_SFR_OCR_OCR5_MASK | EVMU_SFR_OCR_OCR4_MASK),
+                     EVMU_SFR_OCR_OCR5_MASK);
+
+    GBL_TEST_EXPECT_ERROR();
+    result = EvmuClock_setSystemConfig(pClock,
+                                       EVMU_OSCILLATOR_CF,
+                                       EVMU_CLOCK_DIVIDER_1);
+    GBL_TEST_VERIFY(!GBL_RESULT_SUCCESS(result));
+    GBL_TEST_COMPARE(GBL_CTX_LAST_RESULT(), GBL_RESULT_ERROR_INVALID_ARG);
+    GBL_CTX_CLEAR_LAST_RECORD();
+
+    baseTimerDefaultHalfSecondQuartz_(pFixture);
+    baseTimerCycleClockModes_(pFixture);
+    baseTimerStopClearsCounter_(pFixture);
+    baseTimerT0PrescalerSource_(pFixture);
+
+    GBL_TEST_CASE_END;
+}
+
+static void baseTimerDefaultHalfSecondQuartz_(GblTestFixture* pFixture) {
+    GBL_CTX_BEGIN(NULL);
+
+    EvmuPic_* pPic_ = EVMU_PIC_(pFixture->pDevice->pPic);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    pPic_->intReq = 0;
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_OCR,
+                      EVMU_SFR_OCR_OCR7_MASK |
+                      EVMU_SFR_OCR_OCR5_MASK |
+                      EVMU_SFR_OCR_OCR1_MASK |
+                      EVMU_SFR_OCR_OCR0_MASK);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_ISL, 0xc0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR,
+                      EVMU_SFR_BTCR_OP_CTRL_MASK |
+                      EVMU_SFR_BTCR_INT0_REQ_EN_MASK);
+
+    stepBaseTimer_(pFixture->pDevice, 2730);
+
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     16380);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT0_SRC_MASK,
+                     0);
+    GBL_TEST_COMPARE(pPic_->intReq & (1u << EVMU_IRQ_EXT_INT3_TBASE), 0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     2);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT0_SRC_MASK,
+                     EVMU_SFR_BTCR_INT0_SRC_MASK);
+    GBL_TEST_COMPARE(pPic_->intReq & (1u << EVMU_IRQ_EXT_INT3_TBASE),
+                     (EvmuIrqMask)(1u << EVMU_IRQ_EXT_INT3_TBASE));
+
+    GBL_CTX_END_BLOCK();
+}
+
+static void baseTimerCycleClockModes_(GblTestFixture* pFixture) {
+    GBL_CTX_BEGIN(NULL);
+
+    EvmuPic_* pPic_ = EVMU_PIC_(pFixture->pDevice->pPic);
+    const EvmuWord islCycleClock = 0xd0;
+    const EvmuWord btcrInt1Fast2 =
+        EVMU_SFR_BTCR_OP_CTRL_MASK |
+        EVMU_SFR_BTCR_INT1_REQ_EN_MASK |
+        EVMU_SFR_BTCR_INT0_CYCLE_CTRL_MASK |
+        0x20u;
+    const EvmuWord btcrInt1Fast8 =
+        EVMU_SFR_BTCR_OP_CTRL_MASK |
+        EVMU_SFR_BTCR_INT1_REQ_EN_MASK |
+        EVMU_SFR_BTCR_INT0_CYCLE_CTRL_MASK |
+        0x30u;
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    pPic_->intReq = 0;
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_ISL, islCycleClock);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR,
+                      EVMU_SFR_BTCR_OP_CTRL_MASK |
+                      EVMU_SFR_BTCR_INT1_REQ_EN_MASK);
+
+    stepBaseTimer_(pFixture->pDevice, 31);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     30);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     31);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     32);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     EVMU_SFR_BTCR_INT1_SRC_MASK);
+    GBL_TEST_COMPARE(pPic_->intReq & (1u << EVMU_IRQ_EXT_INT3_TBASE),
+                     (EvmuIrqMask)(1u << EVMU_IRQ_EXT_INT3_TBASE));
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    pPic_->intReq = 0;
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR,
+                      EVMU_SFR_BTCR_OP_CTRL_MASK |
+                      EVMU_SFR_BTCR_INT1_REQ_EN_MASK |
+                      EVMU_SFR_BTCR_INT1_CYCLE_CTRL_MASK);
+
+    stepBaseTimer_(pFixture->pDevice, 127);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     128);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     EVMU_SFR_BTCR_INT1_SRC_MASK);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR,
+                      EVMU_SFR_BTCR_OP_CTRL_MASK |
+                      EVMU_SFR_BTCR_INT0_REQ_EN_MASK |
+                      EVMU_SFR_BTCR_INT0_CYCLE_CTRL_MASK);
+    pPic_->intReq = 0;
+
+    stepBaseTimer_(pFixture->pDevice, 63);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT0_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT0_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     64);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT0_SRC_MASK,
+                     EVMU_SFR_BTCR_INT0_SRC_MASK);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, btcrInt1Fast2);
+    pPic_->intReq = 0;
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     2);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     EVMU_SFR_BTCR_INT1_SRC_MASK);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, btcrInt1Fast8);
+    pPic_->intReq = 0;
+
+    stepBaseTimer_(pFixture->pDevice, 7);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     8);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     EVMU_SFR_BTCR_INT1_SRC_MASK);
+
+    GBL_CTX_END_BLOCK();
+}
+
+static void baseTimerStopClearsCounter_(GblTestFixture* pFixture) {
+    GBL_CTX_BEGIN(NULL);
+
+    const EvmuWord islCycleClock = 0xd0;
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_ISL, islCycleClock);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR,
+                      EVMU_SFR_BTCR_OP_CTRL_MASK |
+                      EVMU_SFR_BTCR_INT1_REQ_EN_MASK);
+
+    stepBaseTimer_(pFixture->pDevice, 20);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     20);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 40);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     0);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         (EVMU_SFR_BTCR_INT0_SRC_MASK | EVMU_SFR_BTCR_INT1_SRC_MASK),
+                     0);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR,
+                      EVMU_SFR_BTCR_OP_CTRL_MASK |
+                      EVMU_SFR_BTCR_INT1_REQ_EN_MASK);
+    stepBaseTimer_(pFixture->pDevice, 33);
+
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     32);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     EVMU_SFR_BTCR_INT1_SRC_MASK);
+
+    GBL_CTX_END_BLOCK();
+}
+
+static void baseTimerT0PrescalerSource_(GblTestFixture* pFixture) {
+    GBL_CTX_BEGIN(NULL);
+
+    const EvmuWord islT0Prescaler = 0xf0;
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR, 0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0PRR, 0xfd);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_ISL, islT0Prescaler);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR,
+                      EVMU_SFR_BTCR_OP_CTRL_MASK |
+                      EVMU_SFR_BTCR_INT1_REQ_EN_MASK);
+
+    stepBaseTimer_(pFixture->pDevice, 95);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     31);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     0);
+
+    stepBaseTimer_(pFixture->pDevice, 1);
+    GBL_TEST_COMPARE(EVMU_TIMERS_(pFixture->pDevice->pTimers)->baseTimer.counter,
+                     32);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_BTCR) &
+                         EVMU_SFR_BTCR_INT1_SRC_MASK,
+                     EVMU_SFR_BTCR_INT1_SRC_MASK);
+
+    GBL_CTX_END_BLOCK();
+}
+
+GBL_TEST_CASE(clockHoldStopsCpuAndTimers) {
+    EvmuDevice_* pDevice_ = EVMU_DEVICE_(pFixture->pDevice);
+    EvmuLcd* pLcd = pFixture->pDevice->pLcd;
+    const EvmuPc startPc = EvmuCpu_pc(pFixture->pDevice->pCpu);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0PRR, 0xff);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0LR, 0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0HR, 0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T0CNT,
+                      EVMU_SFR_T0CNT_P0LRUN_MASK |
+                      EVMU_SFR_T0CNT_P0HRUN_MASK);
+
+    pDevice_->pTimers->timer0.base.tl = 0x12;
+    pDevice_->pTimers->timer0.base.th = 0x34;
+
+    EvmuLcd_setPixel(pLcd, 0, 0, GBL_TRUE);
+    EvmuLcd_setPixel(pLcd, 1, 0, GBL_FALSE);
+    EvmuIBehavior_update(EVMU_IBEHAVIOR(pLcd),
+                         EvmuLcd_refreshRateTicks(pLcd) * EVMU_LCD_SCREEN_REFRESH_DIVISOR);
+    GBL_TEST_VERIFY(EvmuLcd_decoratedPixel(pLcd, 0, 0) !=
+                    EvmuLcd_decoratedPixel(pLcd, 1, 0));
+
+    pLcd->screenChanged = GBL_FALSE;
+    EvmuClock_setSystemState(pFixture->pDevice->pClock,
+                             EVMU_CLOCK_SYSTEM_STATE_HOLD);
+    EvmuIBehavior_update(EVMU_IBEHAVIOR(pFixture->pDevice->pCpu),
+                         EVMU_CLOCK_OSC_QUARTZ_TCYC_1_6 * 16);
+
+    GBL_TEST_COMPARE(pLcd->screenChanged, GBL_TRUE);
+    GBL_TEST_COMPARE(EvmuCpu_pc(pFixture->pDevice->pCpu), startPc);
+    GBL_TEST_COMPARE(pDevice_->pTimers->timer0.base.tl, 0x12);
+    GBL_TEST_COMPARE(pDevice_->pTimers->timer0.base.th, 0x34);
+    GBL_TEST_COMPARE(EvmuLcd_pixel(pLcd, 0, 0), GBL_TRUE);
+    GBL_TEST_COMPARE(EvmuLcd_pixel(pLcd, 1, 0), GBL_FALSE);
+    GBL_TEST_COMPARE(EvmuLcd_decoratedPixel(pLcd, 0, 0), 255);
+    GBL_TEST_COMPARE(EvmuLcd_decoratedPixel(pLcd, 1, 0), 255);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_PCON),
+                     EVMU_SFR_PCON_HOLD_MASK);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(clockHoldCancelsOnPort3Input) {
+    EvmuGamepad* pGamepad = pFixture->pDevice->pGamepad;
+
+    EvmuClock_setSystemState(pFixture->pDevice->pClock,
+                             EVMU_CLOCK_SYSTEM_STATE_HOLD);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_P3INT,
+                      EVMU_SFR_P3INT_P32INT_MASK);
+    pFixture->pDevice->pLcd->screenChanged = GBL_FALSE;
+
+    pGamepad->a = GBL_TRUE;
+    EvmuIBehavior_update(EVMU_IBEHAVIOR(pGamepad), 0);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_PCON),
+                     0);
+    GBL_TEST_COMPARE(pFixture->pDevice->pLcd->screenChanged, GBL_TRUE);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_P3INT) &
+                         EVMU_SFR_P3INT_P31INT_MASK,
+                     EVMU_SFR_P3INT_P31INT_MASK);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(waveTransitions) {
+    EvmuWave wave = EVMU_WAVE_0_0;
+
+    EvmuWave_reset(&wave);
+    GBL_TEST_COMPARE(wave, EVMU_WAVE_X_X);
+    GBL_TEST_COMPARE(EvmuWave_logicPrevious(&wave), EVMU_LOGIC_X);
+    GBL_TEST_COMPARE(EvmuWave_logicCurrent(&wave), EVMU_LOGIC_X);
+    GBL_TEST_VERIFY(EvmuWave_hasStayedUnknown(&wave));
+
+    EvmuWave_update(&wave, EVMU_LOGIC_0);
+    GBL_TEST_COMPARE(wave, EVMU_WAVE_X_0);
+    GBL_TEST_COMPARE(EvmuWave_logicPrevious(&wave), EVMU_LOGIC_X);
+    GBL_TEST_COMPARE(EvmuWave_logicCurrent(&wave), EVMU_LOGIC_0);
+    GBL_TEST_VERIFY(EvmuWave_wasLogicUnknown(&wave));
+    GBL_TEST_VERIFY(EvmuWave_isLogicLow(&wave));
+    GBL_TEST_VERIFY(EvmuWave_hasChangedKnown(&wave));
+    GBL_TEST_VERIFY(EvmuWave_hasChangedValid(&wave));
+
+    EvmuWave_update(&wave, EVMU_LOGIC_1);
+    GBL_TEST_COMPARE(wave, EVMU_WAVE_0_1);
+    GBL_TEST_VERIFY(EvmuWave_hasChanged(&wave));
+    GBL_TEST_VERIFY(EvmuWave_hasChangedEdge(&wave));
+    GBL_TEST_VERIFY(EvmuWave_hasChangedEdgeRising(&wave));
+    GBL_TEST_VERIFY(EvmuWave_wasLogicLow(&wave));
+    GBL_TEST_VERIFY(EvmuWave_isLogicHigh(&wave));
+
+    EvmuWave_update(&wave, EVMU_LOGIC_1);
+    GBL_TEST_COMPARE(wave, EVMU_WAVE_1_1);
+    GBL_TEST_VERIFY(EvmuWave_hasStayed(&wave));
+    GBL_TEST_VERIFY(EvmuWave_hasStayedHigh(&wave));
+    GBL_TEST_VERIFY(!EvmuWave_hasChanged(&wave));
+
+    EvmuWave_update(&wave, EVMU_LOGIC_0);
+    GBL_TEST_COMPARE(wave, EVMU_WAVE_1_0);
+    GBL_TEST_VERIFY(EvmuWave_hasChangedEdge(&wave));
+    GBL_TEST_VERIFY(EvmuWave_hasChangedEdgeFalling(&wave));
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(fileReadWithoutHeaderSpansBlocks) {
+    enum {
+        kIconCount    = 3,
+        kPayloadBytes = 96
+    };
+
+    EvmuNewFileInfo info;
+    unsigned char fileData[EVMU_FAT_BLOCK_SIZE * 4] = {0};
+    unsigned char payload[kPayloadBytes];
+    unsigned char readData[kPayloadBytes];
+    EvmuVms* pVms = (EvmuVms*)fileData;
+
+    const size_t headerBytes = sizeof(EvmuVms) + kIconCount * EVMU_VMS_ICON_BITMAP_SIZE;
+    EvmuDirEntry* pEntry = NULL;
+
+    GBL_TEST_VERIFY(headerBytes > EVMU_FAT_BLOCK_SIZE);
+
+    pVms->iconCount = kIconCount;
+    pVms->animSpeed = 1;
+    pVms->eyecatchType = EVMU_VMS_EYECATCH_NONE;
+    pVms->crc = 1;
+    pVms->dataBytes = kPayloadBytes;
+
+    memset(fileData + sizeof(EvmuVms), 0xa5, headerBytes - sizeof(EvmuVms));
+
+    for(size_t i = 0; i < kPayloadBytes; ++i) {
+        payload[i] = (unsigned char)(0x40 + i);
+        fileData[headerBytes + i] = payload[i];
+    }
+
+    EvmuNewFileInfo_init(&info,
+                         "HDRSPAN",
+                         headerBytes + kPayloadBytes,
+                         EVMU_FILE_TYPE_DATA,
+                         EVMU_COPY_ALLOWED);
+
+    pEntry = EvmuFileManager_alloc(pFixture->pDevice->pFileMgr, &info, fileData);
+    GBL_TEST_VERIFY(pEntry);
+    GBL_TEST_VERIFY(pEntry->firstBlock != 0);
+    GBL_TEST_COMPARE(EvmuFileManager_visibleBytes(pFixture->pDevice->pFileMgr,
+                                                  pEntry,
+                                                  GBL_TRUE),
+                     pEntry->fileSize * EVMU_FAT_BLOCK_SIZE);
+    GBL_TEST_COMPARE(EvmuFileManager_visibleBytes(pFixture->pDevice->pFileMgr,
+                                                  pEntry,
+                                                  GBL_FALSE),
+                     pEntry->fileSize * EVMU_FAT_BLOCK_SIZE - headerBytes);
+
+    memset(readData, 0, sizeof(readData));
+    GBL_TEST_COMPARE(EvmuFileManager_read(pFixture->pDevice->pFileMgr,
+                                          pEntry,
+                                          readData,
+                                          sizeof(readData),
+                                          0,
+                                          GBL_FALSE),
+                     sizeof(readData));
+    GBL_TEST_COMPARE(memcmp(readData, payload, sizeof(payload)), 0);
+
+    memset(readData, 0, sizeof(readData));
+    GBL_TEST_COMPARE(EvmuFileManager_read(pFixture->pDevice->pFileMgr,
+                                          pEntry,
+                                          readData,
+                                          16,
+                                          7,
+                                          GBL_FALSE),
+                     16);
+    GBL_TEST_COMPARE(memcmp(readData, payload + 7, 16), 0);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(vmsComputeCrcDoesNotMutate) {
+    enum { kDataBytes = 32 };
+
+    unsigned char fileBytes[sizeof(EvmuVms) + kDataBytes] = {0};
+    unsigned char original[sizeof(fileBytes)];
+    EvmuVms* pVms = (EvmuVms*)fileBytes;
+    EvmuVms headerCopy;
+    uint16_t expected = 0;
+
+    pVms->iconCount = 0;
+    pVms->animSpeed = 0;
+    pVms->eyecatchType = EVMU_VMS_EYECATCH_NONE;
+    pVms->crc = 0x1234;
+    pVms->dataBytes = kDataBytes;
+
+    for(size_t i = 0; i < kDataBytes; ++i)
+        fileBytes[sizeof(EvmuVms) + i] = (unsigned char)(0x40 + i);
+
+    memcpy(original, fileBytes, sizeof(fileBytes));
+
+    headerCopy = *pVms;
+    headerCopy.crc = 0;
+    expected = gblHashCrc16BitPartial(&headerCopy, sizeof(headerCopy), &expected);
+    expected = gblHashCrc16BitPartial(fileBytes + sizeof(EvmuVms), kDataBytes, &expected);
+
+    GBL_TEST_COMPARE(EvmuVms_computeCrc(pVms), expected);
+    GBL_TEST_COMPARE(memcmp(fileBytes, original, sizeof(fileBytes)), 0);
+    GBL_TEST_COMPARE(pVms->crc, 0x1234);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(vmsGuessFileTypeRejectsImpossibleDataSize) {
+    EvmuVms vms = {0};
+
+    vms.iconCount = 0;
+    vms.animSpeed = 0;
+    vms.eyecatchType = EVMU_VMS_EYECATCH_NONE;
+    vms.crc = 1;
+    vms.dataBytes =
+        EVMU_FAT_BLOCK_USERDATA_SIZE_DEFAULT * EVMU_FAT_BLOCK_SIZE + 1;
+
+    GBL_TEST_COMPARE(EvmuVms_guessFileType(&vms), EVMU_FILE_TYPE_NONE);
+
+    vms.dataBytes = 32;
+    GBL_TEST_COMPARE(EvmuVms_guessFileType(&vms), EVMU_FILE_TYPE_DATA);
+
+    vms.crc = 0;
+    GBL_TEST_COMPARE(EvmuVms_guessFileType(&vms), EVMU_FILE_TYPE_GAME);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(vmiFromVmsFileRejectsTruncatedInput) {
+    unsigned char shortBytes[64] = {0};
+    unsigned char oneBlock[EVMU_FAT_BLOCK_SIZE] = {0};
+    EvmuVms* pInvalidHeader = (EvmuVms*)oneBlock;
+    EvmuVmi vmi;
+
+    GBL_TEST_EXPECT_ERROR();
+    GBL_TEST_VERIFY(!GBL_RESULT_SUCCESS(EvmuVmi_fromVmsFile(&vmi,
+                                                            shortBytes,
+                                                            sizeof(shortBytes))));
+    GBL_TEST_COMPARE(GBL_CTX_LAST_RESULT(), EVMU_RESULT_ERROR_INVALID_FILE);
+    GBL_CTX_CLEAR_LAST_RECORD();
+
+    pInvalidHeader->eyecatchType = EVMU_VMS_EYECATCH_COUNT;
+
+    GBL_TEST_EXPECT_ERROR();
+    GBL_TEST_VERIFY(!GBL_RESULT_SUCCESS(EvmuVmi_fromVmsFile(&vmi,
+                                                            oneBlock,
+                                                            sizeof(oneBlock))));
+    GBL_TEST_COMPARE(GBL_CTX_LAST_RESULT(), EVMU_RESULT_ERROR_INVALID_FILE);
+    GBL_CTX_CLEAR_LAST_RECORD();
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(vmsCreateIconsArgb4444AllocatesDestSize) {
+    unsigned char fileBytes[sizeof(EvmuVms) + EVMU_VMS_ICON_BITMAP_SIZE] = {0};
+    EvmuVms* pVms = (EvmuVms*)fileBytes;
+    GblRingList* pIcons = NULL;
+    GblByteArray* pIcon = NULL;
+
+    pVms->iconCount = 1;
+    pVms->animSpeed = 0;
+    pVms->eyecatchType = EVMU_VMS_EYECATCH_NONE;
+    pVms->palette[0] = 0xffff;
+
+    pIcons = EvmuVms_createIconsArgb4444(pVms);
+    GBL_TEST_VERIFY(pIcons);
+    GBL_TEST_COMPARE(GblRingList_size(pIcons), 1);
+
+    pIcon = (GblByteArray*)GblRingList_front(pIcons);
+    GBL_TEST_VERIFY(pIcon);
+    GBL_TEST_COMPARE(pIcon->size,
+                     sizeof(uint16_t) *
+                     EVMU_VMS_ICON_BITMAP_WIDTH *
+                     EVMU_VMS_ICON_BITMAP_HEIGHT);
+
+    GblRingList_unref(pIcons, byteArrayUnref_, NULL);
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(vmsCreateIconsArgb4444WritesSequentialPixels) {
+    unsigned char fileBytes[sizeof(EvmuVms) + EVMU_VMS_ICON_BITMAP_SIZE] = {0};
+    EvmuVms* pVms = (EvmuVms*)fileBytes;
+    GblRingList* pIcons = NULL;
+    GblByteArray* pIcon = NULL;
+    uint16_t pixels[2] = {0};
+
+    pVms->iconCount = 1;
+    pVms->animSpeed = 0;
+    pVms->eyecatchType = EVMU_VMS_EYECATCH_NONE;
+    pVms->palette[1] = 0x1111;
+    pVms->palette[2] = 0x2222;
+
+    // First packed byte contains palette indices 1 then 2.
+    fileBytes[sizeof(EvmuVms)] = 0x12;
+
+    pIcons = EvmuVms_createIconsArgb4444(pVms);
+    GBL_TEST_VERIFY(pIcons);
+
+    pIcon = (GblByteArray*)GblRingList_front(pIcons);
+    GBL_TEST_VERIFY(pIcon);
+    GBL_CTX_VERIFY_CALL(GblByteArray_read(pIcon, 0, sizeof(pixels), pixels));
+
+    GBL_TEST_COMPARE(pixels[0], 0x1111);
+    GBL_TEST_COMPARE(pixels[1], 0x2222);
+
+    GblRingList_unref(pIcons, byteArrayUnref_, NULL);
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(lcdBlankWhenDisabled) {
+    EvmuLcd* pLcd = pFixture->pDevice->pLcd;
+
+    EvmuLcd_setPixel(pLcd, 0, 0, GBL_TRUE);
+    EvmuLcd_setPixel(pLcd, 1, 0, GBL_FALSE);
+
+    EvmuIBehavior_update(EVMU_IBEHAVIOR(pLcd),
+                         EvmuLcd_refreshRateTicks(pLcd) * EVMU_LCD_SCREEN_REFRESH_DIVISOR);
+
+    GBL_TEST_COMPARE(EvmuLcd_pixel(pLcd, 0, 0), GBL_TRUE);
+    GBL_TEST_COMPARE(EvmuLcd_pixel(pLcd, 1, 0), GBL_FALSE);
+    GBL_TEST_VERIFY(EvmuLcd_decoratedPixel(pLcd, 0, 0) !=
+                    EvmuLcd_decoratedPixel(pLcd, 1, 0));
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_VCCR, 0x00);
+
+    GBL_TEST_COMPARE(EvmuLcd_screenEnabled(pLcd), GBL_FALSE);
+    GBL_TEST_COMPARE(EvmuLcd_pixel(pLcd, 0, 0), GBL_TRUE);
+    GBL_TEST_COMPARE(EvmuLcd_pixel(pLcd, 1, 0), GBL_FALSE);
+    GBL_TEST_COMPARE(EvmuLcd_decoratedPixel(pLcd, 0, 0), 255);
+    GBL_TEST_COMPARE(EvmuLcd_decoratedPixel(pLcd, 1, 0), 255);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(buzzerMode1ComparatorLatchesPerCycle) {
+    EvmuCpu_* pCpu_ = EVMU_CPU_(pFixture->pCpu);
+    uint16_t period = 0;
+    uint8_t invPulseLength = 0;
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_NOP;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_NOP);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT, 0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_P1, 0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_P1DDR, EVMU_SFR_P1DDR_P17DDR_MASK);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_P1FCR, EVMU_SFR_P1FCR_P17FCR_MASK);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LR, 0xf0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LC, 0xf1);
+    EvmuRam_writeData(pFixture->pRam,
+                      EVMU_ADDRESS_SFR_T1CNT,
+                      EVMU_SFR_T1CNT_ELDT1C_MASK |
+                      EVMU_SFR_T1CNT_T1LRUN_MASK);
+
+    EvmuBuzzer_tone(pFixture->pDevice->pBuzzer, &period, &invPulseLength);
+    GBL_TEST_COMPARE(period, 16);
+    GBL_TEST_COMPARE(invPulseLength, 1);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LC, 0xf8);
+
+    EvmuBuzzer_tone(pFixture->pDevice->pBuzzer, &period, &invPulseLength);
+    GBL_TEST_COMPARE(period, 16);
+    GBL_TEST_COMPARE(invPulseLength, 1);
+
+    for(size_t i = 0; i < 32; ++i) {
+        if(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT) &
+           EVMU_SFR_T1CNT_T1LOVF_MASK)
+            break;
+
+        EvmuTimers_update(pFixture->pDevice->pTimers);
+    }
+
+    GBL_TEST_VERIFY(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT) &
+                    EVMU_SFR_T1CNT_T1LOVF_MASK);
+
+    EvmuBuzzer_tone(pFixture->pDevice->pBuzzer, &period, &invPulseLength);
+    GBL_TEST_COMPARE(period, 16);
+    GBL_TEST_COMPARE(invPulseLength, 8);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(buzzerMode1Eldt1cGatesComparatorUpdates) {
+    EvmuCpu_* pCpu_ = EVMU_CPU_(pFixture->pCpu);
+    uint16_t period = 0;
+    uint8_t invPulseLength = 0;
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_NOP;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_NOP);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT, 0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_P1, 0x00);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_P1DDR, EVMU_SFR_P1DDR_P17DDR_MASK);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_P1FCR, EVMU_SFR_P1FCR_P17FCR_MASK);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LR, 0xf0);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LC, 0xf1);
+    EvmuRam_writeData(pFixture->pRam,
+                      EVMU_ADDRESS_SFR_T1CNT,
+                      EVMU_SFR_T1CNT_T1LRUN_MASK);
+    EvmuBuzzer_tone(pFixture->pDevice->pBuzzer, &period, &invPulseLength);
+    GBL_TEST_COMPARE(period, 16);
+    GBL_TEST_COMPARE(invPulseLength, 1);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LC, 0xf8);
+
+    for(size_t i = 0; i < 32; ++i) {
+        if(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT) &
+           EVMU_SFR_T1CNT_T1LOVF_MASK)
+            break;
+
+        EvmuTimers_update(pFixture->pDevice->pTimers);
+    }
+
+    GBL_TEST_VERIFY(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT) &
+                    EVMU_SFR_T1CNT_T1LOVF_MASK);
+
+    EvmuBuzzer_tone(pFixture->pDevice->pBuzzer, &period, &invPulseLength);
+    GBL_TEST_COMPARE(period, 16);
+    GBL_TEST_COMPARE(invPulseLength, 1);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT, 0x00);
+    EvmuRam_writeData(pFixture->pRam,
+                      EVMU_ADDRESS_SFR_T1CNT,
+                      EVMU_SFR_T1CNT_T1LRUN_MASK);
+
+    EvmuBuzzer_tone(pFixture->pDevice->pBuzzer, &period, &invPulseLength);
+    GBL_TEST_COMPARE(period, 16);
+    GBL_TEST_COMPARE(invPulseLength, 8);
+
+    GBL_TEST_CASE_END;
+}
+
+GBL_TEST_CASE(timer1ReloadCascade16) {
+    EvmuDevice_* pDevice_ = EVMU_DEVICE_(pFixture->pDevice);
+    EvmuCpu_*    pCpu_    = EVMU_CPU_(pFixture->pCpu);
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_MOV;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_MOV);
+
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1LR,  0xfe);
+    EvmuRam_writeData(pFixture->pRam, EVMU_ADDRESS_SFR_T1HR,  0xfe);
+    pDevice_->pTimers->timer1.base.tl = 0xfe;
+    pDevice_->pTimers->timer1.base.th = 0xfe;
+    EvmuRam_writeData(pFixture->pRam,
+                      EVMU_ADDRESS_SFR_T1CNT,
+                      EVMU_SFR_T1CNT_T1LONG_MASK |
+                      EVMU_SFR_T1CNT_T1LRUN_MASK |
+                      EVMU_SFR_T1CNT_T1HRUN_MASK);
+    EVMU_DEVICE_(pFixture->pDevice)->pTimers->timer1.startDelayCycles = 0;
+
+    EvmuTimers_update(pFixture->pDevice->pTimers);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1L), 0xfe);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1H), 0xff);
+    GBL_TEST_VERIFY(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT) &
+                    EVMU_SFR_T1CNT_T1LOVF_MASK);
+    GBL_TEST_VERIFY(!(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT) &
+                      EVMU_SFR_T1CNT_T1HOVF_MASK));
+
+    pCpu_->curInstr.encoded.bytes[EVMU_INSTRUCTION_BYTE_OPCODE] = EVMU_OPCODE_NOP;
+    pCpu_->curInstr.pFormat = EvmuIsa_format(EVMU_OPCODE_NOP);
+
+    EvmuTimers_update(pFixture->pDevice->pTimers);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1L), 0xff);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1H), 0xff);
+
+    EvmuTimers_update(pFixture->pDevice->pTimers);
+
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1L), 0xfe);
+    GBL_TEST_COMPARE(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1H), 0xfe);
+    GBL_TEST_VERIFY(EvmuRam_readData(pFixture->pRam, EVMU_ADDRESS_SFR_T1CNT) &
+                    EVMU_SFR_T1CNT_T1HOVF_MASK);
+
+    GBL_TEST_CASE_END;
+}
+
 GBL_TEST_REGISTER(nop,
                   ld,
                   ldInd,
@@ -2542,4 +3576,14 @@ GBL_TEST_REGISTER(nop,
                   ldc,
                   reti,
                   ldf,
-                  stf);
+                  stf,
+                  timerStartDelay16,
+                  timerCounterWriteStopped,
+                  clockTicksPerCycle,
+                  clockApiReflectsAndUpdatesRegisters,
+                  waveTransitions,
+                  fileReadWithoutHeaderSpansBlocks,
+                  lcdBlankWhenDisabled,
+                  buzzerMode1ComparatorLatchesPerCycle,
+                  buzzerMode1Eldt1cGatesComparatorUpdates,
+                  timer1ReloadCascade16);


### PR DESCRIPTION
This PR replaces the old BIOS-only Base Timer approximation with a real BTCR/ISL-driven implementation and fixes a cycle-clock start-edge bug found by hardware probes.

## What changed

- Replace the hard-coded `0.1s / 0.5s` Base Timer behavior with a real 14-bit Base Timer counter.
- Drive the Base Timer from the documented source selected by `ISL`:
  - quartz
  - cycle clock
  - T0 prescaler
- Decode Base Timer interrupt source rates from `BTCR` instead of assuming the BIOS default cadence.
- Preserve correct stop/reconfigure behavior:
  - stopping the Base Timer clears the counter
  - OCR / ISL / T0PRR changes reset the relevant timing remainder
- Fix cycle-clock start timing so the Base Timer does not incorrectly count the instruction that starts it via `BTCR`.
