### PR TITLE
Fix Shenmue minigame

### DIFF
--- a/lib/source/hw/evmu_ram.c
+++ b/lib/source/hw/evmu_ram.c
@@ -176,6 +176,11 @@ EVMU_EXPORT EVMU_RESULT EvmuRam_writeData(EvmuRam* pSelf, EvmuAddress addr, Evmu
         }
         GBL_CTX_DONE();
         break;
+    case EVMU_ADDRESS_SFR_VRMAD2:
+        // Only VRMAD8(0-bit) is writable. The upper bits read back as 1s, but they do
+        // not participate in the WRAM address used by VTRBF accesses.
+        val &= 0x1;
+        break;
     case EVMU_ADDRESS_SFR_EXT: {
 #if 1
         //changing CPU mode (change imem between BIOS in rom and APP in flash)

--- a/lib/source/hw/evmu_wram.c
+++ b/lib/source/hw/evmu_wram.c
@@ -5,7 +5,7 @@
 EVMU_EXPORT EvmuAddress EvmuWram_accessAddress(const EvmuWram* pSelf) {
     EvmuRam_* pRam_ = EVMU_WRAM_(pSelf)->pRam;
 
-    return pRam_->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_VRMAD2)] << 8 |
+    return (pRam_->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_VRMAD2)] & 0x1) << 8 |
            pRam_->sfr[EVMU_SFR_OFFSET(EVMU_ADDRESS_SFR_VRMAD1)];
 }
 


### PR DESCRIPTION
The rendering bug was VRMAD2: hardware only uses bit 0 as VRMAD8, but libevmu was storing the whole byte and then using all 8 bits when calculating the WRAM address for VTRBF. Shenmue writes VRMAD2 directly in a few places, so that could turn a valid 0x0xx/0x1xx WRAM access into something huge and trigger the out-of-range XRAM errors.