### PR TITLE
Fix Hidden Region default size

### DIFF
--- a/doc/pages/filesystem.dox
+++ b/doc/pages/filesystem.dox
@@ -143,7 +143,7 @@
     Block # of the first Hidden block (default: `200`).</p>
 
     <p><b>[0x052] Hidden Size (2 bytes):</b><br>
-    Size (in blocks) of the Hidden region (default: `31`).</p>
+    Size (in blocks) of the Hidden region (default: `41`).</p>
 
     <p><b>[0x054] Game First (2 bytes):</b><br>
     Block # where the first block of a GAME file must be written (default: `0`).</p>


### PR DESCRIPTION
I think the Hidden Region default size, is going to be `256 - UserRegionSize - DirTableSize - FATSize - RootBlockSize`.  
So, `256 - 200 - 13 - 1 - 1 == 41`.

I think this tracks with certain VMU tools allowing "unlocking" the hidden region on your VMU and expanding the capacity to 241 blocks.
Probably `31` was just a math error from awhile ago.